### PR TITLE
Fix typo in OBS integration labels

### DIFF
--- a/frontend/src/components/dashboard/OBSInfoCard.vue
+++ b/frontend/src/components/dashboard/OBSInfoCard.vue
@@ -38,7 +38,7 @@
             </v-chip>
             <v-chip color="teal" variant="outlined" size="small">
               <v-icon start size="small">mdi-arrow-up-bold-hexagon-outline</v-icon>
-              先行率
+              先攻率
             </v-chip>
           </div>
         </v-card-text>

--- a/frontend/src/composables/useOBSConfiguration.ts
+++ b/frontend/src/composables/useOBSConfiguration.ts
@@ -73,7 +73,7 @@ export function useOBSConfiguration() {
     { label: '先行勝率', value: 'first_turn_win_rate', selected: true },
     { label: '後攻勝率', value: 'second_turn_win_rate', selected: true },
     { label: 'コイン勝率', value: 'coin_win_rate', selected: true },
-    { label: '先行率', value: 'go_first_rate', selected: true },
+    { label: '先攻率', value: 'go_first_rate', selected: true },
   ]);
 
   // ドラッグ&ドロップの状態管理

--- a/frontend/src/views/OBSOverlayView.vue
+++ b/frontend/src/views/OBSOverlayView.vue
@@ -66,7 +66,7 @@ const allDisplayItems: OBSDisplayItemDefinition[] = [
   { key: 'first_turn_win_rate', label: '先行勝率', format: (v) => v !== undefined ? `${(v as number).toFixed(1)}%` : '-' },
   { key: 'second_turn_win_rate', label: '後攻勝率', format: (v) => v !== undefined ? `${(v as number).toFixed(1)}%` : '-' },
   { key: 'coin_win_rate', label: 'コイン勝率', format: (v) => v !== undefined ? `${(v as number).toFixed(1)}%` : '-' },
-  { key: 'go_first_rate', label: '先行率', format: (v) => v !== undefined ? `${(v as number).toFixed(1)}%` : '-' },
+  { key: 'go_first_rate', label: '先攻率', format: (v) => v !== undefined ? `${(v as number).toFixed(1)}%` : '-' },
 ];
 
 // 表示する項目をフィルタリング（URLパラメータの順番を保持）


### PR DESCRIPTION
## Summary
- correct the OBS dashboard chip label from 先行率 to 先攻率
- update OBS configuration option label to 先攻率
- fix OBS overlay display item label to 先攻率

## Testing
- not run (UI text change)


------
https://chatgpt.com/codex/tasks/task_e_68f9cf47c03c832c8fabcd0e4f997882