### PR TITLE
feat: OBS連携で無効なURLが発行されるのを防ぐUX改善

### DIFF
--- a/frontend/src/components/dashboard/OBSConfigPanel.vue
+++ b/frontend/src/components/dashboard/OBSConfigPanel.vue
@@ -68,6 +68,17 @@
           @update:model-value="$emit('update:limit', Number($event))"
         ></v-text-field>
 
+        <!-- 配信開始からが無効な場合 -->
+        <v-alert
+          v-if="isFromStartInvalid"
+          type="warning"
+          variant="tonal"
+          class="mb-4"
+          density="compact"
+        >
+          デュエルの記録がまだありません。「配信開始から」を使用するには、最低1回デュエルを記録してください。
+        </v-alert>
+
         <!-- ゲームモード選択 -->
         <v-select
           :model-value="gameMode"
@@ -172,9 +183,16 @@
           density="compact"
           readonly
           class="mb-2"
+          :disabled="isFromStartInvalid"
         >
           <template #append-inner>
-            <v-btn icon variant="text" size="small" @click="$emit('copy-url')">
+            <v-btn
+              icon
+              variant="text"
+              size="small"
+              :disabled="isFromStartInvalid"
+              @click="$emit('copy-url')"
+            >
               <v-icon>{{ urlCopied ? 'mdi-check' : 'mdi-content-copy' }}</v-icon>
             </v-btn>
           </template>
@@ -205,6 +223,7 @@ interface DisplayItem {
 interface Props {
   modelValue: boolean;
   periodType: 'monthly' | 'recent' | 'from_start';
+  isFromStartInvalid: boolean;
   year: number;
   month: number;
   limit: number;

--- a/frontend/src/composables/useOBSConfiguration.ts
+++ b/frontend/src/composables/useOBSConfiguration.ts
@@ -175,6 +175,13 @@ export function useOBSConfiguration() {
   /**
    * OBSオーバーレイURL
    */
+  /**
+   * 「配信開始から」が無効（デュエル記録がない）かどうかを判定
+   */
+  const isFromStartInvalid = computed(() => {
+    return obsPeriodType.value === 'from_start' && obsStartId.value === null;
+  });
+
   const obsUrl = computed(() => {
     const baseUrl = window.location.origin;
     // localStorageから直接トークンを取得
@@ -236,6 +243,10 @@ export function useOBSConfiguration() {
    * OBS URLをクリップボードにコピー
    */
   const copyOBSUrl = async () => {
+    if (isFromStartInvalid.value) {
+      notificationStore.warning('デュエル記録がないため、URLをコピーできません');
+      return;
+    }
     try {
       await navigator.clipboard.writeText(obsUrl.value);
       urlCopied.value = true;
@@ -277,6 +288,7 @@ export function useOBSConfiguration() {
     coinWinRateColor,
     recommendedSizeText,
     obsUrl,
+    isFromStartInvalid,
 
     // Functions
     handleDragStart,


### PR DESCRIPTION
OBS連携機能で「配信開始から」を選択した際、デュエル記録がないとバックエンドが400エラーを返していました。

この問題に対し、フロントエンドで事前に条件をチェックし、警告メッセージを表示してURLのコピーを無効にするように修正しました。 これにより、ユーザーが不正なURLをコピーしてしまうのを防ぎ、より分かりやすいUIを実現しました。