### PR TITLE
docs(phase1): モデルと型定義にドキュメントを追加（命名規則は維持）

### DIFF
--- a/backend/app/models/deck.py
+++ b/backend/app/models/deck.py
@@ -1,3 +1,10 @@
+"""
+デッキモデル
+
+ユーザーが使用するデッキと対戦相手のデッキを管理するモデル。
+is_opponentフラグにより、自分のデッキと相手のデッキを区別します。
+"""
+
 from __future__ import annotations
 
 from datetime import datetime, timezone
@@ -13,13 +20,31 @@ if TYPE_CHECKING:
 
 
 class Deck(Base):
+    """
+    デッキモデル
+
+    プレイヤーデッキと相手デッキの両方を管理します。
+    is_opponentフラグで区別され、統計情報やデッキ相性分析に使用されます。
+    """
+
     __tablename__ = "decks"
 
+    # 基本情報
     id: Mapped[int] = mapped_column(primary_key=True, index=True)
-    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
-    name: Mapped[str] = mapped_column(String, nullable=False)
-    is_opponent: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
-    active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id"), nullable=False
+    )  # デッキの所有者
+    name: Mapped[str] = mapped_column(String, nullable=False)  # デッキ名
+
+    # デッキ属性
+    is_opponent: Mapped[bool] = mapped_column(
+        Boolean, default=False, nullable=False
+    )  # True=相手デッキ, False=自分のデッキ
+    active: Mapped[bool] = mapped_column(
+        Boolean, default=True, nullable=False
+    )  # True=アクティブ, False=アーカイブ済み
+
+    # タイムスタンプ
     createdat: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
     )
@@ -28,8 +53,14 @@ class Deck(Base):
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
     )
-    user: Mapped["User"] = relationship("User", back_populates="decks")
-    duels = relationship("Duel", foreign_keys="[Duel.deck_id]", back_populates="deck")
+
+    # リレーションシップ
+    user: Mapped["User"] = relationship(
+        "User", back_populates="decks"
+    )  # デッキの所有者
+    duels = relationship(
+        "Duel", foreign_keys="[Duel.deck_id]", back_populates="deck"
+    )  # このデッキを使用した対戦
     opponent_duels = relationship(
         "Duel", foreign_keys="[Duel.opponentDeck_id]", back_populates="opponent_deck"
-    )
+    )  # このデッキと対戦した履歴

--- a/backend/app/models/duel.py
+++ b/backend/app/models/duel.py
@@ -1,3 +1,11 @@
+"""
+対戦履歴モデル
+
+トレーディングカードゲームの対戦結果を記録・管理するためのモデル。
+ユーザーが使用したデッキ、対戦相手のデッキ、勝敗、ゲームモード、
+ターン順などの詳細な情報を保持します。
+"""
+
 from datetime import datetime, timezone
 
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String
@@ -7,24 +15,41 @@ from app.models import Base
 
 
 class Duel(Base):
+    """
+    対戦履歴モデル
+
+    各対戦の詳細情報を記録します。統計情報の計算やデッキ相性分析の
+    基礎データとして使用されます。
+    """
+
     __tablename__ = "duels"
 
+    # 基本情報
     id = Column(Integer, primary_key=True, index=True)
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
-    deck_id = Column(Integer, ForeignKey("decks.id"), nullable=False)
-    opponentDeck_id = Column(Integer, ForeignKey("decks.id"), nullable=False)
+    deck_id = Column(Integer, ForeignKey("decks.id"), nullable=False)  # 使用デッキ
+    opponentDeck_id = Column(
+        Integer, ForeignKey("decks.id"), nullable=False
+    )  # 相手のデッキ（注: 本番DB仕様でcamelCase）
 
-    result = Column(Boolean, nullable=False)
+    # 対戦結果
+    result = Column(Boolean, nullable=False)  # True=勝利, False=敗北
     game_mode = Column(
         String(10), nullable=False, default="RANK", server_default="RANK"
     )  # RANK, RATE, EVENT, DC
+
+    # ゲームモード別の値
     rank = Column(Integer, nullable=True)  # ランクモード時のランク（1-15: B2～M1）
     rate_value = Column(Integer, nullable=True)  # レートモード時のレート数値
     dc_value = Column(Integer, nullable=True)  # DCモード時のDC数値
-    coin = Column(Boolean, nullable=False)
-    first_or_second = Column(Boolean, nullable=False)
-    played_date = Column(DateTime(timezone=True), nullable=False)
-    notes = Column(String, nullable=True)
+
+    # 対戦詳細
+    coin = Column(Boolean, nullable=False)  # True=コイントス勝利, False=敗北
+    first_or_second = Column(Boolean, nullable=False)  # True=先攻, False=後攻
+    played_date = Column(DateTime(timezone=True), nullable=False)  # 対戦日時
+    notes = Column(String, nullable=True)  # メモ（任意）
+
+    # タイムスタンプ
     create_date = Column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
     )
@@ -34,8 +59,11 @@ class Duel(Base):
         onupdate=lambda: datetime.now(timezone.utc),
     )
 
-    user = relationship("User", back_populates="duels")
-    deck = relationship("Deck", foreign_keys=[deck_id], back_populates="duels")
+    # リレーションシップ
+    user = relationship("User", back_populates="duels")  # この対戦を記録したユーザー
+    deck = relationship(
+        "Deck", foreign_keys=[deck_id], back_populates="duels"
+    )  # 使用したデッキ
     opponent_deck = relationship(
         "Deck", foreign_keys=[opponentDeck_id], back_populates="opponent_duels"
-    )
+    )  # 対戦相手のデッキ

--- a/backend/app/services/general_stats_service.py
+++ b/backend/app/services/general_stats_service.py
@@ -24,7 +24,29 @@ class GeneralStatsService:
         return query
 
     def _calculate_general_stats(self, duels: List[Duel]) -> Dict[str, Any]:
-        """デュエルのリストから基本的な統計情報を計算する"""
+        """
+        デュエルのリストから基本的な統計情報を計算する
+
+        Args:
+            duels: 対戦記録のリスト
+
+        Returns:
+            統計情報の辞書。以下のキーを含む:
+            - total_duels: 総対戦数
+            - win_count: 勝利数
+            - lose_count: 敗北数
+            - win_rate: 勝率（%）
+            - first_turn_win_rate: 先攻時の勝率（%）
+            - second_turn_win_rate: 後攻時の勝率（%）
+            - coin_win_rate: コイントス勝利時の勝率（%）
+            - go_first_rate: 先攻を引く割合（%）
+
+        処理フロー:
+            1. 総対戦数を計算
+            2. 勝敗をresultフラグで分類（True=勝利、False=敗北）
+            3. 先攻/後攻をfirst_or_secondフラグで分類（True=先攻、False=後攻）
+            4. 各カテゴリーの勝率を計算
+        """
         total_duels = len(duels)
         if total_duels == 0:
             return {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -36,25 +36,31 @@ export interface DeckUpdate {
 
 export type GameMode = 'RANK' | 'RATE' | 'EVENT' | 'DC';
 
+/**
+ * 対戦履歴インターフェース
+ *
+ * トレーディングカードゲームの対戦結果を表現します。
+ * バックエンドのDuelモデルに対応しています。
+ */
 export interface Duel {
   id: number;
-  deck_id: number;
-  opponentDeck_id: number;
-  result: boolean; // true = win, false = lose
+  deck_id: number; // 使用したデッキのID
+  opponentDeck_id: number; // 相手のデッキのID（注: 本番DB仕様でcamelCase）
+  result: boolean; // true=勝利, false=敗北
   game_mode: GameMode; // RANK, RATE, EVENT, DC
-  rank?: number; // ランクモード時のランク（1-15）
+  rank?: number; // ランクモード時のランク（1-15: B2～M1）
   rate_value?: number; // レートモード時のレート数値
   dc_value?: number; // DCモード時のDC数値
-  coin: boolean; // true = heads, false = tails
-  first_or_second: boolean; // true = first, false = second
-  played_date: string;
-  notes?: string;
-  create_date: string;
-  update_date: string;
-  user_id: number;
+  coin: boolean; // true=コイントス勝利, false=敗北
+  first_or_second: boolean; // true=先攻, false=後攻
+  played_date: string; // 対戦日時（ISO8601形式）
+  notes?: string; // メモ（任意）
+  create_date: string; // 作成日時
+  update_date: string; // 更新日時
+  user_id: number; // ユーザーID
   // フロントエンドで追加するフィールド
-  deck?: Deck;
-  opponentdeck?: Deck;
+  deck?: Deck; // 使用したデッキの詳細情報（結合データ）
+  opponentdeck?: Deck; // 相手のデッキの詳細情報（結合データ）
   no?: number; // テーブル表示用の連番
 }
 


### PR DESCRIPTION
## 概要

Phase 1の一環として、コードの可読性を向上させるドキュメントを追加しました。

**重要**: 既存の命名規則（`opponentDeck_id`, `result`, `coin`, `first_or_second`）は
本番DBスキーマとの互換性のため、**そのまま維持**しています。

## 変更内容

### バックエンドモデル

#### `backend/app/models/duel.py`
- ✅ モジュールレベルdocstring追加
- ✅ 各フィールドにインラインコメント追加  
- ✅ 曖昧なフィールドの意味を明記:
  - `result`: True=勝利, False=敗北
  - `coin`: True=コイントス勝利, False=敗北
  - `first_or_second`: True=先攻, False=後攻
  - `opponentDeck_id`: 相手のデッキ（注: 本番DB仕様でcamelCase）

#### `backend/app/models/deck.py`
- ✅ モジュールレベルdocstring追加
- ✅ 各フィールドにインラインコメント追加
- ✅ `is_opponent`フラグの説明追加

### バックエンドサービス

#### `backend/app/services/general_stats_service.py`
- ✅ `_calculate_general_stats()`に詳細なdocstring追加
- ✅ Args, Returns, 処理フローを文書化

### フロントエンド型定義

#### `frontend/src/types/index.ts`
- ✅ `Duel`インターフェースに詳細なJSDocコメント追加
- ✅ 各フィールドの意味を明記

## 前回のエラーとの違い

前回（PR#22-28）は命名規則を変更しようとしてデータベースとの不一致エラーが発生しましたが、
今回は**コメント追加のみ**で、コード変更は一切ありません。

## 期待効果

- 📖 **可読性向上**: フィールドの意味が一目で理解可能
- ⏱️ **レビュー時間短縮**: コメントにより意図が明確
- 🎓 **オンボーディング改善**: 新規メンバーが理解しやすい
- 🤝 **人間主導の開発**: AI依存からの脱却

## 次のステップ

このPRがマージされたら、以下の順で進めます：

1. ✅ **Phase 1完了** (このPR)
2. 📝 **Phase 2**: クエリビルダー共通化（既存命名維持）
3. 🔧 **Phase 3**: リンター設定強化（PR#29）
4. 🚀 **Phase 4**: 命名規則統一（データベースマイグレーション含む）

## 関連ドキュメント

- `docs/readability-improvement-roadmap.md` - Phase 1計画
- `docs/code-readability-guide.md` - コメント記述ガイドライン

🤖 Generated with [Claude Code](https://claude.com/claude-code)