### PR TITLE
feat(frontend): OBSオーバーレイにレート/DC表示項目を追加

### DIFF
--- a/frontend/src/composables/useOBSConfiguration.ts
+++ b/frontend/src/composables/useOBSConfiguration.ts
@@ -67,10 +67,12 @@ export function useOBSConfiguration() {
     return 'info';
   });
 
-  // 表示項目
+  // 表示項目（初期値を設定）
   const displayItems = ref([
     { label: '使用デッキ', value: 'current_deck', selected: true },
     { label: 'ランク', value: 'current_rank', selected: true },
+    { label: 'レート', value: 'current_rate', selected: true },
+    { label: 'DC', value: 'current_dc', selected: true },
     { label: '総試合数', value: 'total_duels', selected: false },
     { label: '勝率', value: 'win_rate', selected: true },
     { label: '先攻勝率', value: 'first_turn_win_rate', selected: true },


### PR DESCRIPTION
## 概要
OBSオーバーレイの表示項目設定に「レート」と「DC」のチェックボックスを追加し、初期値を適切に設定しました。

## 変更内容
- `frontend/src/composables/useOBSConfiguration.ts` に以下の変更を実施:
  - displayItemsリストに「レート」(current_rate)を追加
  - displayItemsリストに「DC」(current_dc)を追加
  - 両項目をデフォルトで選択状態に設定 (selected: true)
  - 表示項目の初期値を適切に設定することで、全表示機能の必要性を削減

## テスト内容
- [x] フロントエンドビルドが成功することを確認
- [x] TypeScriptの型エラーがないことを確認

## 影響範囲
- OBS設定ダイアログの表示項目選択UI
- OBSオーバーレイのURL生成パラメータ

🤖 Generated with [Claude Code](https://claude.com/claude-code)