### PR TITLE
feat(frontend): OBS設定のゲームモードを必須化し初期値をランクに設定

### DIFF
--- a/frontend/src/composables/useOBSConfiguration.ts
+++ b/frontend/src/composables/useOBSConfiguration.ts
@@ -71,6 +71,8 @@ export function useOBSConfiguration() {
   const displayItems = ref([
     { label: '使用デッキ', value: 'current_deck', selected: true },
     { label: 'ランク', value: 'current_rank', selected: true },
+    { label: 'レート', value: 'current_rate', selected: false },
+    { label: 'DC', value: 'current_dc', selected: false },
     { label: '総試合数', value: 'total_duels', selected: false },
     { label: '勝率', value: 'win_rate', selected: true },
     { label: '先攻勝率', value: 'first_turn_win_rate', selected: true },


### PR DESCRIPTION
## 概要
OBS設定のゲームモードを任意から必須に変更し、初期値を「ランク」に設定しました。
また、表示項目リストに「レート」と「DC」のチェックボックスを追加しました。

## 変更内容
- `frontend/src/composables/useOBSConfiguration.ts` に以下の変更を実施:
  - `obsGameMode`の初期値を`undefined`から`'RANK'`に変更
  - `obsGameMode`の型を`string | undefined`から`string`に変更（必須化）
  - URL生成時の条件分岐を削除し、`game_mode`パラメータを常に追加
  - `displayItems`リストに「レート」(`current_rate`)と「DC」(`current_dc`)を追加
  - レート・DCはデフォルトで非選択状態（`selected: false`）

## テスト内容
- [x] フロントエンドビルドが成功することを確認
- [x] TypeScriptの型エラーがないことを確認
- [x] 500エラーの原因（mainブランチからのリベース不足）を解決

## 影響範囲
- OBS設定ダイアログのゲームモード選択（初期値が「ランク」に設定される）
- OBS設定ダイアログの表示項目リスト（レートとDCのチェックボックスが追加される）
- OBSオーバーレイのURL生成（game_modeパラメータが常に含まれる）

## 技術的な詳細

### 修正したエラー
元々の`feature/improve-obs-ui`ブランチはPR #52（レート/DC値のfloat対応）がマージされる前のmainから分岐していたため、以下のエラーが発生していました:
```
ResponseValidationError: Input should be a valid integer, got a number with a fractional part
Input: 1500.03
```

これを解決するため、mainブランチにリベースして最新の変更（float型対応）を取り込みました。

### コミット履歴
1. `feat(frontend): OBS設定のゲームモードを必須化し初期値をランクに設定`
   - ゲームモードを必須項目に変更
   - 初期値を'RANK'に設定
   
2. `fix(frontend): OBS設定の表示項目にレートとDCを追加`
   - displayItemsリストに「レート」と「DC」を追加
   - デフォルトでは非選択状態に設定

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>