### PR TITLE
fix: adjust shared statistics month boundary

### DIFF
--- a/backend/app/services/deck_distribution_service.py
+++ b/backend/app/services/deck_distribution_service.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 from app.models.deck import Deck
 from app.models.duel import Duel
 from app.utils.query_builders import apply_range_filter, build_base_duels_query
+from app.utils.datetime_utils import month_range_utc
 
 
 class DeckDistributionService:
@@ -55,9 +56,10 @@ class DeckDistributionService:
         opponent_deck_id: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
         """月間の相手デッキ分布を取得。"""
+        start_utc, end_utc = month_range_utc(year, month)
         base_query = build_base_duels_query(db, user_id, game_mode).filter(
-            extract("year", Duel.played_date) == year,
-            extract("month", Duel.played_date) == month,
+            Duel.played_date >= start_utc,
+            Duel.played_date < end_utc,
         )
 
         # デッキフィルター

--- a/backend/app/services/general_stats_service.py
+++ b/backend/app/services/general_stats_service.py
@@ -4,10 +4,10 @@
 
 from typing import Any, Dict, List, Optional
 
-from sqlalchemy import extract
 from sqlalchemy.orm import Session
 
 from app.models.duel import Duel
+from app.utils.datetime_utils import month_range_utc
 
 
 class GeneralStatsService:
@@ -75,10 +75,11 @@ class GeneralStatsService:
         start_id: Optional[int] = None,
     ) -> Dict[str, Any]:
         """指定された年月におけるユーザーの全体的なデュエル統計を取得。"""
-        query = db.query(Duel).filter(
-            Duel.user_id == user_id,
-            extract("year", Duel.played_date) == year,
-            extract("month", Duel.played_date) == month,
+        start_utc, end_utc = month_range_utc(year, month)
+        query = (
+            db.query(Duel)
+            .filter(Duel.user_id == user_id)
+            .filter(Duel.played_date >= start_utc, Duel.played_date < end_utc)
         )
         if game_mode:
             query = query.filter(Duel.game_mode == game_mode)

--- a/backend/app/services/matchup_service.py
+++ b/backend/app/services/matchup_service.py
@@ -4,11 +4,11 @@
 
 from typing import Any, Dict, List, Optional
 
-from sqlalchemy import extract
 from sqlalchemy.orm import Session
 
 from app.models.deck import Deck
 from app.models.duel import Duel
+from app.utils.datetime_utils import month_range_utc, year_range_utc
 from app.utils.query_builders import apply_range_filter, build_base_duels_query
 
 
@@ -30,9 +30,20 @@ class MatchupService:
         """デッキ相性表のデータを取得。"""
         query = build_base_duels_query(db, user_id, game_mode)
 
-        if year is not None:
-            query = query.filter(extract("year", Duel.played_date) == year)
-        if month is not None:
+        if year is not None and month is not None:
+            start_utc, end_utc = month_range_utc(year, month)
+            query = query.filter(
+                Duel.played_date >= start_utc, Duel.played_date < end_utc
+            )
+        elif year is not None:
+            start_utc, end_utc = year_range_utc(year)
+            query = query.filter(
+                Duel.played_date >= start_utc, Duel.played_date < end_utc
+            )
+        elif month is not None:
+            # 従来の挙動維持（年未指定時）
+            from sqlalchemy import extract
+
             query = query.filter(extract("month", Duel.played_date) == month)
 
         # デッキフィルター

--- a/backend/app/services/win_rate_service.py
+++ b/backend/app/services/win_rate_service.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 
 from app.models.deck import Deck
 from app.models.duel import Duel
+from app.utils.datetime_utils import month_range_utc, year_range_utc
 from app.utils.query_builders import apply_range_filter, build_base_duels_query
 
 
@@ -63,9 +64,17 @@ class WinRateService:
         """ユーザー自身の各デッキの勝率を計算。"""
         query = build_base_duels_query(db, user_id, game_mode)
 
-        if year is not None:
-            query = query.filter(extract("year", Duel.played_date) == year)
-        if month is not None:
+        if year is not None and month is not None:
+            start_utc, end_utc = month_range_utc(year, month)
+            query = query.filter(
+                Duel.played_date >= start_utc, Duel.played_date < end_utc
+            )
+        elif year is not None:
+            start_utc, end_utc = year_range_utc(year)
+            query = query.filter(
+                Duel.played_date >= start_utc, Duel.played_date < end_utc
+            )
+        elif month is not None:
             query = query.filter(extract("month", Duel.played_date) == month)
 
         # デッキフィルター

--- a/backend/app/utils/datetime_utils.py
+++ b/backend/app/utils/datetime_utils.py
@@ -1,0 +1,51 @@
+"""Datetime utility helpers for timezone-aware range calculations."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Tuple
+from zoneinfo import ZoneInfo
+
+
+# TODO: In the future this should be configurable per user. For now we assume JST.
+DEFAULT_TIMEZONE = ZoneInfo("Asia/Tokyo")
+
+
+def month_range_utc(year: int, month: int, tz: ZoneInfo = DEFAULT_TIMEZONE) -> Tuple[datetime, datetime]:
+    """Return the UTC start (inclusive) and end (exclusive) timestamps for the given month.
+
+    Args:
+        year: Target year in the local timezone.
+        month: Target month in the local timezone (1-12).
+        tz: Local timezone to interpret the year/month in (defaults to JST).
+
+    Returns:
+        A tuple of (start_utc, end_utc) datetimes.
+    """
+
+    if month < 1 or month > 12:
+        raise ValueError("month must be between 1 and 12")
+
+    start_local = datetime(year, month, 1, tzinfo=tz)
+    if month == 12:
+        end_local = datetime(year + 1, 1, 1, tzinfo=tz)
+    else:
+        end_local = datetime(year, month + 1, 1, tzinfo=tz)
+
+    return start_local.astimezone(timezone.utc), end_local.astimezone(timezone.utc)
+
+
+def year_range_utc(year: int, tz: ZoneInfo = DEFAULT_TIMEZONE) -> Tuple[datetime, datetime]:
+    """Return the UTC start (inclusive) and end (exclusive) timestamps for the given year."""
+
+    start_local = datetime(year, 1, 1, tzinfo=tz)
+    end_local = datetime(year + 1, 1, 1, tzinfo=tz)
+    return start_local.astimezone(timezone.utc), end_local.astimezone(timezone.utc)
+
+
+def current_month_range_utc(tz: ZoneInfo = DEFAULT_TIMEZONE) -> Tuple[datetime, datetime]:
+    """Convenience helper that returns the current month range in UTC for the given timezone."""
+
+    now_local = datetime.now(tz)
+    return month_range_utc(now_local.year, now_local.month, tz)
+

--- a/backend/tests/test_timezone_statistics.py
+++ b/backend/tests/test_timezone_statistics.py
@@ -1,0 +1,63 @@
+from datetime import datetime, timezone
+
+from fastapi import status
+
+from app.models.deck import Deck
+from app.models.duel import Duel
+
+
+def _insert_decks_and_duel(db_session, user_id: int) -> None:
+    my_deck = Deck(user_id=user_id, name="My Deck", is_opponent=False)
+    opp_deck = Deck(user_id=user_id, name="Opp Deck", is_opponent=True)
+    db_session.add_all([my_deck, opp_deck])
+    db_session.commit()
+
+    duel = Duel(
+        user_id=user_id,
+        deck_id=my_deck.id,
+        opponent_deck_id=opp_deck.id,
+        won_coin_toss=True,
+        is_going_first=True,
+        is_win=True,
+        game_mode="RATE",
+        rate_value=1500.0,
+        played_date=datetime(2024, 5, 31, 15, 0, tzinfo=timezone.utc),
+        notes=None,
+    )
+    db_session.add(duel)
+    db_session.commit()
+
+
+def test_statistics_monthly_uses_local_timezone(
+    authenticated_client, db_session, test_user
+):
+    """Statistics API should treat month boundaries in the configured local timezone."""
+
+    _insert_decks_and_duel(db_session, test_user.id)
+
+    response = authenticated_client.get("/statistics", params={"year": 2024, "month": 6})
+    assert response.status_code == status.HTTP_200_OK
+
+    stats = response.json()
+    assert stats["RATE"]["overall_stats"]["total_duels"] == 1
+
+
+def test_shared_statistics_respects_local_timezone(
+    authenticated_client, db_session, test_user
+):
+    """Shared statistics endpoints should mirror the same timezone-aware month boundaries."""
+
+    _insert_decks_and_duel(db_session, test_user.id)
+
+    create_response = authenticated_client.post(
+        "/shared-statistics/",
+        json={"year": 2024, "month": 6, "game_mode": "RATE"},
+    )
+    assert create_response.status_code == status.HTTP_201_CREATED
+    share_id = create_response.json()["share_id"]
+
+    shared_response = authenticated_client.get(f"/shared-statistics/{share_id}")
+    assert shared_response.status_code == status.HTTP_200_OK
+
+    shared_stats = shared_response.json()["statistics_data"]
+    assert shared_stats["RATE"]["overall_stats"]["total_duels"] == 1


### PR DESCRIPTION
## Summary
- 月次集計にJSTを考慮したUTC範囲を適用し、共有リンクとOBSで直近30戦しか表示されない問題を解消
- timezoneユーティリティを追加し、各統計サービスの年/月フィルタとvalue sequenceの相手デッキフィルタを修正
- 月跨ぎの回帰を検証するtimezone向けテストを追加

## Testing
- docker compose exec backend pytest