### PR TITLE
fix(test): add conftest.py to resolve pytest import error

### DIFF
--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -1,0 +1,11 @@
+"""
+Pytest configuration for backend tests
+"""
+
+import sys
+from pathlib import Path
+
+# Add backend directory to Python path to allow importing app module
+backend_dir = Path(__file__).parent
+if str(backend_dir) not in sys.path:
+    sys.path.insert(0, str(backend_dir))


### PR DESCRIPTION
Adds backend/conftest.py to configure sys.path for pytest. This resolves the "ModuleNotFoundError: No module named 'app'" error that occurred when running tests from the project root or any directory outside of backend/.

The conftest.py adds the backend directory to sys.path, allowing pytest to correctly import the app module and its submodules.