### PR TITLE
fix: resolve timezone-aware datetime comparison issues

### DIFF
--- a/backend/app/api/routers/shared_statistics.py
+++ b/backend/app/api/routers/shared_statistics.py
@@ -70,11 +70,16 @@ def get_shared_statistics(
             status_code=status.HTTP_404_NOT_FOUND, detail="共有リンクが見つかりません"
         )
 
-    if shared_link.expires_at and shared_link.expires_at < datetime.now(timezone.utc):
-        raise HTTPException(
-            status_code=status.HTTP_410_GONE,
-            detail="共有リンクの有効期限が切れています",
-        )
+    if shared_link.expires_at:
+        expires_at = shared_link.expires_at
+        # Ensure expires_at is timezone-aware for comparison
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        if expires_at < datetime.now(timezone.utc):
+            raise HTTPException(
+                status_code=status.HTTP_410_GONE,
+                detail="共有リンクの有効期限が切れています",
+            )
 
     statistics_data = get_all_statistics(
         db=db,
@@ -138,11 +143,16 @@ def export_shared_duels_csv(
         )
 
     # 有効期限の確認
-    if shared_link.expires_at and shared_link.expires_at < datetime.now(timezone.utc):
-        raise HTTPException(
-            status_code=status.HTTP_410_GONE,
-            detail="この共有リンクは期限切れです。",
-        )
+    if shared_link.expires_at:
+        expires_at = shared_link.expires_at
+        # Ensure expires_at is timezone-aware for comparison
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        if expires_at < datetime.now(timezone.utc):
+            raise HTTPException(
+                status_code=status.HTTP_410_GONE,
+                detail="この共有リンクは期限切れです。",
+            )
 
     user_id = shared_link.user_id
 

--- a/backend/app/models/password_reset_token.py
+++ b/backend/app/models/password_reset_token.py
@@ -31,7 +31,13 @@ class PasswordResetToken(Base):
     user: Mapped["User"] = relationship("User", back_populates="password_reset_tokens")
 
     def is_expired(self) -> bool:
-        return datetime.now(timezone.utc) > self.expires_at
+        now = datetime.now(timezone.utc)
+        # Ensure expires_at is timezone-aware for comparison
+        expires_at = self.expires_at
+        if expires_at.tzinfo is None:
+            # If naive, assume UTC
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        return now > expires_at
 
     def __repr__(self):
         return f"<PasswordResetToken id={self.id} user_id={self.user_id} expires_at={self.expires_at}>"

--- a/backend/tests/test_auth_api.py
+++ b/backend/tests/test_auth_api.py
@@ -1,0 +1,254 @@
+"""
+認証APIのテスト
+
+ログイン、ログアウト、パスワードリセットなどの
+認証関連エンドポイントのテストを含む
+"""
+
+import pytest
+from fastapi import status
+
+from app.core.security import get_password_hash, verify_password
+from app.models.password_reset_token import PasswordResetToken
+from app.models.user import User
+
+
+class TestLogin:
+    """ログインエンドポイントのテスト"""
+
+    def test_login_success(self, client, test_user):
+        """正常なログイン"""
+        response = client.post(
+            "/auth/login",
+            json={"email": "test@example.com", "password": "testpassword"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["message"] == "Login successful"
+        assert "user" in data
+        assert data["user"]["email"] == "test@example.com"
+        assert data["user"]["username"] == "testuser"
+        assert "access_token" in data  # OBS連携のため含まれる
+        assert "access_token" in response.cookies  # HttpOnly Cookie
+
+    def test_login_invalid_email(self, client):
+        """存在しないメールアドレスでのログイン"""
+        response = client.post(
+            "/auth/login",
+            json={"email": "nonexistent@example.com", "password": "password"},
+        )
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert "メールアドレスまたはパスワードが正しくありません" in response.json()["detail"]
+
+    def test_login_invalid_password(self, client, test_user):
+        """誤ったパスワードでのログイン"""
+        response = client.post(
+            "/auth/login",
+            json={"email": "test@example.com", "password": "wrongpassword"},
+        )
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert "メールアドレスまたはパスワードが正しくありません" in response.json()["detail"]
+
+    def test_login_missing_fields(self, client):
+        """必須フィールドが欠けている場合"""
+        response = client.post(
+            "/auth/login",
+            json={"email": "test@example.com"},  # passwordが欠けている
+        )
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    def test_login_empty_password(self, client, test_user):
+        """空のパスワードでのログイン"""
+        response = client.post(
+            "/auth/login",
+            json={"email": "test@example.com", "password": ""},
+        )
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+class TestLogout:
+    """ログアウトエンドポイントのテスト"""
+
+    def test_logout_success(self, client):
+        """正常なログアウト"""
+        response = client.post("/auth/logout")
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["message"] == "Logout successful"
+
+        # Cookieがクリアされているか確認
+        cookies = response.cookies
+        if "access_token" in cookies:
+            assert cookies["access_token"] == ""
+
+
+class TestPasswordReset:
+    """パスワードリセットエンドポイントのテスト"""
+
+    def test_forgot_password_existing_user(self, client, test_user, db_session):
+        """存在するユーザーのパスワードリセット要求"""
+        response = client.post(
+            "/auth/forgot-password",
+            json={"email": "test@example.com"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "パスワード再設定の案内をメールで送信しました" in response.json()["message"]
+
+        # トークンがデータベースに作成されているか確認
+        token_entry = (
+            db_session.query(PasswordResetToken)
+            .filter(PasswordResetToken.user_id == test_user.id)
+            .first()
+        )
+        # 注: テスト環境ではメール送信が失敗する可能性があるため、
+        # トークン作成のみを確認
+        # assert token_entry is not None
+
+    def test_forgot_password_nonexistent_user(self, client):
+        """存在しないユーザーのパスワードリセット要求（セキュリティのため成功を返す）"""
+        response = client.post(
+            "/auth/forgot-password",
+            json={"email": "nonexistent@example.com"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "パスワード再設定の案内をメールで送信しました" in response.json()["message"]
+
+    def test_reset_password_success(self, client, test_user, db_session):
+        """パスワードリセットの成功"""
+        # トークンを作成
+        from datetime import datetime, timedelta, timezone
+
+        from app.core.security import generate_password_reset_token
+
+        token = generate_password_reset_token()
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
+
+        reset_token_entry = PasswordResetToken(
+            user_id=test_user.id, token=token, expires_at=expires_at
+        )
+        db_session.add(reset_token_entry)
+        db_session.commit()
+
+        # パスワードリセット実行
+        new_password = "newpassword123"
+        response = client.post(
+            "/auth/reset-password",
+            json={
+                "token": token,
+                "new_password": new_password,
+                "confirm_password": new_password,
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "パスワードが正常にリセットされました" in response.json()["message"]
+
+        # パスワードが変更されたか確認
+        db_session.refresh(test_user)
+        assert verify_password(new_password, test_user.passwordhash)
+
+        # トークンが削除されたか確認
+        token_entry = (
+            db_session.query(PasswordResetToken)
+            .filter(PasswordResetToken.token == token)
+            .first()
+        )
+        assert token_entry is None
+
+    def test_reset_password_mismatch(self, client, test_user, db_session):
+        """パスワードと確認パスワードが一致しない場合"""
+        from datetime import datetime, timedelta, timezone
+
+        from app.core.security import generate_password_reset_token
+
+        token = generate_password_reset_token()
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
+
+        reset_token_entry = PasswordResetToken(
+            user_id=test_user.id, token=token, expires_at=expires_at
+        )
+        db_session.add(reset_token_entry)
+        db_session.commit()
+
+        response = client.post(
+            "/auth/reset-password",
+            json={
+                "token": token,
+                "new_password": "newpassword123",
+                "confirm_password": "differentpassword",
+            },
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "一致しません" in response.json()["detail"]
+
+    def test_reset_password_invalid_token(self, client):
+        """無効なトークンでのパスワードリセット"""
+        response = client.post(
+            "/auth/reset-password",
+            json={
+                "token": "invalid_token",
+                "new_password": "newpassword123",
+                "confirm_password": "newpassword123",
+            },
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "無効なトークン" in response.json()["detail"]
+
+    def test_reset_password_expired_token(self, client, test_user, db_session):
+        """有効期限切れトークンでのパスワードリセット"""
+        from datetime import datetime, timedelta, timezone
+
+        from app.core.security import generate_password_reset_token
+
+        token = generate_password_reset_token()
+        # 過去の時刻を設定（期限切れ）
+        expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
+
+        reset_token_entry = PasswordResetToken(
+            user_id=test_user.id, token=token, expires_at=expires_at
+        )
+        db_session.add(reset_token_entry)
+        db_session.commit()
+
+        response = client.post(
+            "/auth/reset-password",
+            json={
+                "token": token,
+                "new_password": "newpassword123",
+                "confirm_password": "newpassword123",
+            },
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "有効期限切れ" in response.json()["detail"]
+
+
+class TestOBSToken:
+    """OBS専用トークンエンドポイントのテスト"""
+
+    def test_get_obs_token_success(self, authenticated_client):
+        """認証済みユーザーのOBSトークン取得"""
+        response = authenticated_client.post("/auth/obs-token")
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert "obs_token" in data
+        assert "expires_in" in data
+        assert data["expires_in"] == 24 * 60 * 60  # 24時間
+        assert data["scope"] == "obs_overlay"
+
+    def test_get_obs_token_unauthenticated(self, client):
+        """未認証ユーザーのOBSトークン取得（失敗）"""
+        response = client.post("/auth/obs-token")
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/backend/tests/test_users_api.py
+++ b/backend/tests/test_users_api.py
@@ -1,0 +1,239 @@
+"""
+ユーザーAPIのテスト
+
+ユーザー作成、取得、更新、削除などのエンドポイントのテストと、
+特に認可チェック（他のユーザーのデータにアクセスできないこと）を確認
+"""
+
+import pytest
+from fastapi import status
+
+from app.core.security import get_password_hash
+from app.models.user import User
+
+
+class TestCreateUser:
+    """ユーザー作成エンドポイントのテスト"""
+
+    def test_create_user_success(self, client, db_session):
+        """正常なユーザー作成"""
+        user_data = {
+            "username": "newuser",
+            "email": "newuser@example.com",
+            "password": "securepassword123",
+        }
+
+        response = client.post("/users/", json=user_data)
+
+        assert response.status_code == status.HTTP_201_CREATED
+        data = response.json()
+        assert data["username"] == "newuser"
+        assert data["email"] == "newuser@example.com"
+        assert "id" in data
+        assert "passwordhash" not in data  # パスワードハッシュは返されない
+
+        # データベースに保存されているか確認
+        user = db_session.query(User).filter(User.email == "newuser@example.com").first()
+        assert user is not None
+        assert user.username == "newuser"
+
+    def test_create_user_duplicate_email(self, client, test_user):
+        """既に存在するメールアドレスでのユーザー作成（失敗）"""
+        user_data = {
+            "username": "anotheruser",
+            "email": "test@example.com",  # 既存のメール
+            "password": "password123",
+        }
+
+        response = client.post("/users/", json=user_data)
+
+        assert response.status_code == status.HTTP_409_CONFLICT
+        assert "既に使用されています" in response.json()["detail"]
+
+    def test_create_user_missing_fields(self, client):
+        """必須フィールドが欠けている場合"""
+        user_data = {
+            "username": "incomplete",
+            # email と password が欠けている
+        }
+
+        response = client.post("/users/", json=user_data)
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    def test_create_user_weak_password(self, client):
+        """弱いパスワードでのユーザー作成"""
+        user_data = {
+            "username": "weakuser",
+            "email": "weak@example.com",
+            "password": "123",  # 短すぎるパスワード
+        }
+
+        response = client.post("/users/", json=user_data)
+
+        # パスワード検証がスキーマで実装されている場合
+        # assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+class TestReadUser:
+    """ユーザー取得エンドポイントのテスト"""
+
+    def test_read_own_user_success(self, authenticated_client, test_user):
+        """自分のユーザー情報を取得（成功）"""
+        response = authenticated_client.get(f"/users/{test_user.id}")
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["id"] == test_user.id
+        assert data["username"] == test_user.username
+        assert data["email"] == test_user.email
+
+    def test_read_other_user_forbidden(self, authenticated_client, test_user, db_session):
+        """他のユーザーの情報を取得（失敗 - 403 Forbidden）"""
+        # 別のユーザーを作成
+        other_user = User(
+            username="otheruser",
+            email="other@example.com",
+            passwordhash=get_password_hash("password"),
+        )
+        db_session.add(other_user)
+        db_session.commit()
+        db_session.refresh(other_user)
+
+        # 他のユーザーの情報を取得しようとする
+        response = authenticated_client.get(f"/users/{other_user.id}")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "権限がありません" in response.json()["detail"]
+
+    def test_read_user_not_found(self, authenticated_client, test_user):
+        """存在しないユーザーを取得（404）"""
+        # 自分のIDの場合でも存在しないIDは404を返すべき
+        # ただし、認可チェックが先に実行されるため、このテストは複雑
+        non_existent_id = 99999
+
+        # このテストは認可チェックとNot Foundの優先順位による
+        # 現在の実装では、まず認可チェックが行われるため、
+        # 他のユーザーIDの場合は403が返される
+        pass
+
+    def test_read_user_unauthenticated(self, client, test_user):
+        """未認証でのユーザー情報取得（401）"""
+        response = client.get(f"/users/{test_user.id}")
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+class TestUpdateUser:
+    """ユーザー更新エンドポイントのテスト"""
+
+    def test_update_own_user_success(self, authenticated_client, test_user, db_session):
+        """自分のユーザー情報を更新（成功）"""
+        update_data = {
+            "username": "updateduser",
+            "theme_preference": "dark",
+        }
+
+        response = authenticated_client.put(f"/users/{test_user.id}", json=update_data)
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["username"] == "updateduser"
+        assert data["theme_preference"] == "dark"
+
+        # データベースが更新されているか確認
+        db_session.refresh(test_user)
+        assert test_user.username == "updateduser"
+
+    def test_update_other_user_forbidden(self, authenticated_client, test_user, db_session):
+        """他のユーザーの情報を更新（失敗 - 403 Forbidden）"""
+        # 別のユーザーを作成
+        other_user = User(
+            username="otheruser",
+            email="other@example.com",
+            passwordhash=get_password_hash("password"),
+        )
+        db_session.add(other_user)
+        db_session.commit()
+        db_session.refresh(other_user)
+
+        update_data = {"username": "hacked"}
+
+        response = authenticated_client.put(f"/users/{other_user.id}", json=update_data)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "権限がありません" in response.json()["detail"]
+
+        # データベースが変更されていないことを確認
+        db_session.refresh(other_user)
+        assert other_user.username == "otheruser"
+
+    def test_update_user_unauthenticated(self, client, test_user):
+        """未認証でのユーザー更新（401）"""
+        update_data = {"username": "hacked"}
+
+        response = client.put(f"/users/{test_user.id}", json=update_data)
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_update_user_invalid_data(self, authenticated_client, test_user):
+        """無効なデータでのユーザー更新"""
+        update_data = {
+            "theme_preference": "invalid_theme",  # 無効なテーマ
+        }
+
+        # スキーマで検証されている場合
+        # response = authenticated_client.put(f"/users/{test_user.id}", json=update_data)
+        # assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+class TestDeleteUser:
+    """ユーザー削除エンドポイントのテスト"""
+
+    def test_delete_own_user_success(self, authenticated_client, test_user, db_session):
+        """自分のアカウントを削除（成功）"""
+        response = authenticated_client.delete(f"/users/{test_user.id}")
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+        # データベースから削除されているか確認
+        user = db_session.query(User).filter(User.id == test_user.id).first()
+        assert user is None
+
+    def test_delete_other_user_forbidden(self, authenticated_client, test_user, db_session):
+        """他のユーザーのアカウントを削除（失敗 - 403 Forbidden）"""
+        # 別のユーザーを作成
+        other_user = User(
+            username="otheruser",
+            email="other@example.com",
+            passwordhash=get_password_hash("password"),
+        )
+        db_session.add(other_user)
+        db_session.commit()
+        db_session.refresh(other_user)
+
+        response = authenticated_client.delete(f"/users/{other_user.id}")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "権限がありません" in response.json()["detail"]
+
+        # データベースから削除されていないことを確認
+        user = db_session.query(User).filter(User.id == other_user.id).first()
+        assert user is not None
+
+    def test_delete_user_unauthenticated(self, client, test_user):
+        """未認証でのユーザー削除（401）"""
+        response = client.delete(f"/users/{test_user.id}")
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+class TestListUsers:
+    """ユーザー一覧取得エンドポイントのテスト"""
+
+    def test_list_users_endpoint_disabled(self, authenticated_client):
+        """ユーザー一覧取得エンドポイントが無効化されていることを確認"""
+        response = authenticated_client.get("/users/")
+
+        # エンドポイントがコメントアウトされているため404が返される
+        assert response.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
Fixes TypeError when comparing offset-naive and offset-aware datetimes in password reset and shared statistics functionality.

Changes:
- Update PasswordResetToken.is_expired() to handle both naive and aware datetimes
- Fix datetime comparisons in shared_statistics router endpoints
- Add test files from develop branch (test_auth_api.py, test_users_api.py)
- Sync users.py router with develop branch (list endpoint commented out)

The fix ensures that when datetimes are retrieved from the database as naive (without timezone info), they are properly converted to UTC-aware datetimes before comparison with datetime.now(timezone.utc).