### PR TITLE
fix(tests): resolve CI test failures

### DIFF
--- a/backend/app/api/routers/auth.py
+++ b/backend/app/api/routers/auth.py
@@ -4,6 +4,7 @@
 
 import logging
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 import resend
 from fastapi import APIRouter, Depends, Header, HTTPException, Response, status
@@ -30,7 +31,9 @@ router = APIRouter(prefix="/auth", tags=["authentication"])
 logger = logging.getLogger(__name__)
 
 # Jinja2テンプレート環境の初期化
-jinja_env = Environment(loader=FileSystemLoader("./app/templates/email"))
+# 現在のファイルからの相対パスでテンプレートディレクトリを指定
+template_dir = Path(__file__).parent.parent.parent / "templates" / "email"
+jinja_env = Environment(loader=FileSystemLoader(str(template_dir)))
 
 
 def _is_safari_browser(user_agent: str) -> bool:

--- a/backend/tests/test_auth_api.py
+++ b/backend/tests/test_auth_api.py
@@ -152,8 +152,11 @@ class TestPasswordReset:
         assert "パスワードが正常にリセットされました" in response.json()["message"]
 
         # パスワードが変更されたか確認
-        db_session.refresh(test_user)
-        assert verify_password(new_password, test_user.passwordhash)
+        # 注: test_userインスタンスはセッションから切り離されているため、
+        # 新しくクエリしてパスワードを確認する
+        updated_user = db_session.query(User).filter(User.id == test_user.id).first()
+        assert updated_user is not None
+        assert verify_password(new_password, updated_user.passwordhash)
 
         # トークンが削除されたか確認
         token_entry = (

--- a/backend/tests/test_users_api.py
+++ b/backend/tests/test_users_api.py
@@ -235,5 +235,7 @@ class TestListUsers:
         """ユーザー一覧取得エンドポイントが無効化されていることを確認"""
         response = authenticated_client.get("/users/")
 
-        # エンドポイントがコメントアウトされているため404が返される
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+        # エンドポイントがコメントアウトされているため、
+        # GET /users/ は存在しないが、POST /users/ は存在するため、
+        # FastAPIは405 Method Not Allowedを返す
+        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED


### PR DESCRIPTION
Fix three failing tests in the CI pipeline:

1. test_forgot_password_existing_user:
   - Fixed template path in auth.py to use absolute path
   - Changed from relative path './app/templates/email' to Path(__file__) based path
   - This ensures template directory is found regardless of working directory

2. test_reset_password_success:
   - Fixed SQLAlchemy session error when refreshing user instance
   - Changed from db_session.refresh(test_user) to re-querying the user
   - This avoids "Instance is not persistent within this Session" error

3. test_list_users_endpoint_disabled:
   - Updated expected status code from 404 to 405
   - GET /users/ returns 405 Method Not Allowed because POST /users/ exists
   - FastAPI returns 405 when path exists but method doesn't, not 404