### PR TITLE
fix(ci): GitHub Actionsワークフローのトークン渡し方を修正

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -17,8 +17,7 @@ jobs:
           # 例: https://github.com/orgs/ORG_NAME/projects/PROJECT_NUMBER
           # または https://github.com/users/USERNAME/projects/PROJECT_NUMBER
           project-url: https://github.com/users/krtw00/projects/1
-        env:
           # GitHub Personal Access Token (PAT) が必要です
           # Settings > Secrets and variables > Actions で設定してください
           # 必要な権限: project (read/write)
-          GITHUB_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          github-token: ${{ secrets.PROJECT_TOKEN }}


### PR DESCRIPTION
## 概要
GitHub ActionsでIssueをProjectに自動追加するワークフローが失敗していた問題を修正しました。

## 問題点
`actions/add-to-project@v1.0.2` アクションに対して、`github-token` を環境変数として渡していましたが、このアクションは入力パラメータとして受け取る必要がありました。

エラーメッセージ:
Input required and not supplied: github-token


## 修正内容
`.github/workflows/add-to-project.yml` を修正し、`github-token` を `with` セクションの入力パラメータとして渡すように変更しました。

**変更前:**
```yaml
env:
  GITHUB_TOKEN: ${{ secrets.PROJECT_TOKEN }}
変更後:

with:
  github-token: ${{ secrets.PROJECT_TOKEN }}
期待される動作
新しいIssueが作成されたときに、自動的にGitHub Project（https://github.com/users/krtw00/projects/1）に追加される
ワークフローがエラーなく正常に完了する
変更ファイル
.github/workflows/add-to-project.yml
テスト計画

新しいIssueを作成してワークフローが正常に動作することを確認

GitHub Actionsのログでエラーが発生していないことを確認
