### PR TITLE
feat: 相性表の勝率を色分け（優勢=赤/劣勢=青）

### DIFF
--- a/frontend/src/components/statistics/StatisticsContent.vue
+++ b/frontend/src/components/statistics/StatisticsContent.vue
@@ -226,11 +226,11 @@ const normalizePercent = (value: number) => {
 
 const formatPercent = (value: number) => `${normalizePercent(value).toFixed(1)}%`;
 
-// 優勢: 赤 / 劣勢: 青（Issue #39 の要件に合わせる）
+// 優勢: 青 / 劣勢: 赤（ユーザー要望により色相を反転）
 const getMatchupColor = (value: number) => {
   const percent = normalizePercent(value);
-  if (percent >= 55) return 'error';
-  if (percent <= 45) return 'info';
+  if (percent >= 55) return 'info';
+  if (percent <= 45) return 'error';
   return undefined;
 };
 

--- a/frontend/src/components/statistics/__tests__/StatisticsContent.test.ts
+++ b/frontend/src/components/statistics/__tests__/StatisticsContent.test.ts
@@ -9,7 +9,7 @@ import StatisticsContent from '../StatisticsContent.vue';
 const vuetify = createVuetify({ components, directives });
 
 describe('StatisticsContent.vue', () => {
-  it('colors matchup win rates (advantage=red, disadvantage=blue)', async () => {
+  it('colors matchup win rates (advantage=blue, disadvantage=red)', async () => {
     const wrapper = mount(StatisticsContent, {
       global: {
         plugins: [vuetify, createTestingPinia({ createSpy: vi.fn })],
@@ -70,21 +70,21 @@ describe('StatisticsContent.vue', () => {
     const percentChips = chips.filter((chip) => chip.text().includes('%'));
 
     const winRateChip = percentChips.find((chip) => chip.text().includes('60.0%'));
-    expect(winRateChip?.props('color')).toBe('error');
+    expect(winRateChip?.props('color')).toBe('info');
 
     const firstChip = percentChips.find((chip) => chip.text().includes('70.0%'));
-    expect(firstChip?.props('color')).toBe('error');
+    expect(firstChip?.props('color')).toBe('info');
 
     const secondChip = percentChips.find((chip) => chip.text().includes('40.0%'));
-    expect(secondChip?.props('color')).toBe('info');
+    expect(secondChip?.props('color')).toBe('error');
 
     const neutralChip = percentChips.find((chip) => chip.text().includes('50.0%'));
     expect(neutralChip?.props('color')).toBeUndefined();
 
     const myDeckChip = percentChips.find((chip) => chip.text().includes('12 / 20'));
-    expect(myDeckChip?.props('color')).toBe('error');
+    expect(myDeckChip?.props('color')).toBe('info');
 
     const myDeckChip2 = percentChips.find((chip) => chip.text().includes('4 / 10'));
-    expect(myDeckChip2?.props('color')).toBe('info');
+    expect(myDeckChip2?.props('color')).toBe('error');
   });
 });

--- a/frontend/src/views/StatisticsView.vue
+++ b/frontend/src/views/StatisticsView.vue
@@ -654,11 +654,11 @@ const normalizePercent = (value: number) => {
 
 const formatPercent = (value: number) => `${normalizePercent(value).toFixed(1)}%`;
 
-// 優勢: 赤 / 劣勢: 青（Issue #39 の要件に合わせる）
+// 優勢: 青 / 劣勢: 赤（ユーザー要望により色相を反転）
 const getMatchupColor = (value: number) => {
   const percent = normalizePercent(value);
-  if (percent >= 55) return 'error';
-  if (percent <= 45) return 'info';
+  if (percent >= 55) return 'info';
+  if (percent <= 45) return 'error';
   return undefined;
 };
 

--- a/frontend/src/views/__tests__/StatisticsView.test.ts
+++ b/frontend/src/views/__tests__/StatisticsView.test.ts
@@ -105,21 +105,21 @@ describe('StatisticsView.vue', () => {
     const percentChips = chips.filter((chip) => chip.text().includes('%'));
 
     const winRateChip = percentChips.find((chip) => chip.text().includes('60.0%'));
-    expect(winRateChip?.props('color')).toBe('error');
+    expect(winRateChip?.props('color')).toBe('info');
 
     const firstChip = percentChips.find((chip) => chip.text().includes('70.0%'));
-    expect(firstChip?.props('color')).toBe('error');
+    expect(firstChip?.props('color')).toBe('info');
 
     const secondChip = percentChips.find((chip) => chip.text().includes('40.0%'));
-    expect(secondChip?.props('color')).toBe('info');
+    expect(secondChip?.props('color')).toBe('error');
 
     const neutralChip = percentChips.find((chip) => chip.text().includes('50.0%'));
     expect(neutralChip?.props('color')).toBeUndefined();
 
     const myDeckChip = percentChips.find((chip) => chip.text().includes('12 / 20'));
-    expect(myDeckChip?.props('color')).toBe('error');
+    expect(myDeckChip?.props('color')).toBe('info');
 
     const myDeckChip2 = percentChips.find((chip) => chip.text().includes('4 / 10'));
-    expect(myDeckChip2?.props('color')).toBe('info');
+    expect(myDeckChip2?.props('color')).toBe('error');
   });
 });


### PR DESCRIPTION
Issue #39\n\n- 相性表の勝率（総合/先行/後攻）をしきい値で色分け\n- 55%以上: 赤、45%以下: 青、その他: ニュートラル\n- 単体テスト追加\n\n※ブランチ削除は確認後に対応します。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds visual emphasis to win rates across statistics tables.
> 
> - Wraps `win_rate`, `win_rate_first`, `win_rate_second` in `VChip` with color via `getMatchupColor` (≥55% → `info`/blue, ≤45% → `error`/red, otherwise neutral) in `StatisticsContent.vue` and `StatisticsView.vue`
> - Introduces `normalizePercent` (handles 0–1 ratios) and `formatPercent` for consistent display
> - Adds unit tests for both components asserting chip colors and basic rendering/API calls
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d75264ce53c2575526eecb937088dcf350ed40a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->