### PR TITLE
fix: デッキ一覧を総対戦数でソート（month無視）

### DIFF
--- a/backend/app/services/statistics_service.py
+++ b/backend/app/services/statistics_service.py
@@ -73,9 +73,18 @@ class StatisticsService:
             if duel.opponent_deck_id:
                 opponent_deck_ids.add(duel.opponent_deck_id)
 
-        # デッキ情報を取得
+        # デッキ情報を取得（並び順は「月ではなく全期間の対戦数」を基準にする）
         my_decks = []
         if my_deck_ids:
+            my_deck_count_query = db.query(Duel.deck_id, func.count(Duel.id)).filter(
+                Duel.user_id == user_id, Duel.deck_id.in_(my_deck_ids)
+            )
+            if game_mode is not None:
+                my_deck_count_query = my_deck_count_query.filter(
+                    Duel.game_mode == game_mode
+                )
+            my_deck_counts = dict(my_deck_count_query.group_by(Duel.deck_id).all())
+
             my_decks_query = (
                 db.query(Deck)
                 .filter(
@@ -83,13 +92,29 @@ class StatisticsService:
                     Deck.id.in_(my_deck_ids),
                     Deck.is_opponent.is_(False),
                 )
-                .order_by(func.lower(Deck.name))
                 .all()
             )
             my_decks = [{"id": deck.id, "name": deck.name} for deck in my_decks_query]
+            my_decks.sort(
+                key=lambda d: (-my_deck_counts.get(d["id"], 0), d["name"].lower())
+            )
 
         opponent_decks = []
         if opponent_deck_ids:
+            opponent_deck_count_query = db.query(
+                Duel.opponent_deck_id, func.count(Duel.id)
+            ).filter(
+                Duel.user_id == user_id,
+                Duel.opponent_deck_id.in_(opponent_deck_ids),
+            )
+            if game_mode is not None:
+                opponent_deck_count_query = opponent_deck_count_query.filter(
+                    Duel.game_mode == game_mode
+                )
+            opponent_deck_counts = dict(
+                opponent_deck_count_query.group_by(Duel.opponent_deck_id).all()
+            )
+
             opponent_decks_query = (
                 db.query(Deck)
                 .filter(
@@ -97,12 +122,14 @@ class StatisticsService:
                     Deck.id.in_(opponent_deck_ids),
                     Deck.is_opponent.is_(True),
                 )
-                .order_by(func.lower(Deck.name))
                 .all()
             )
             opponent_decks = [
                 {"id": deck.id, "name": deck.name} for deck in opponent_decks_query
             ]
+            opponent_decks.sort(
+                key=lambda d: (-opponent_deck_counts.get(d["id"], 0), d["name"].lower())
+            )
 
         return {"my_decks": my_decks, "opponent_decks": opponent_decks}
 

--- a/backend/tests/test_statistics_available_decks.py
+++ b/backend/tests/test_statistics_available_decks.py
@@ -4,7 +4,7 @@ from app.models.deck import Deck
 from app.models.duel import Duel
 
 
-def test_available_decks_are_sorted_by_name(authenticated_client, db_session, test_user):
+def test_available_decks_are_sorted_by_total_duels(authenticated_client, db_session, test_user):
     my_deck = Deck(user_id=test_user.id, name="Zoo", is_opponent=False, active=True)
     opp_a = Deck(user_id=test_user.id, name="Beta", is_opponent=True, active=True)
     opp_b = Deck(user_id=test_user.id, name="Alpha", is_opponent=True, active=True)
@@ -35,7 +35,19 @@ def test_available_decks_are_sorted_by_name(authenticated_client, db_session, te
         played_date=datetime(2026, 1, 16, tzinfo=timezone.utc),
         notes=None,
     )
-    db_session.add_all([duel, duel2])
+    duel3 = Duel(
+        user_id=test_user.id,
+        deck_id=my_deck.id,
+        opponent_deck_id=opp_a.id,
+        is_win=False,
+        game_mode="RANK",
+        rank=1,
+        won_coin_toss=False,
+        is_going_first=False,
+        played_date=datetime(2026, 1, 17, tzinfo=timezone.utc),
+        notes=None,
+    )
+    db_session.add_all([duel, duel2, duel3])
     db_session.commit()
 
     res = authenticated_client.get(
@@ -46,5 +58,4 @@ def test_available_decks_are_sorted_by_name(authenticated_client, db_session, te
     payload = res.json()
 
     assert payload["my_decks"] == [{"id": my_deck.id, "name": "Zoo"}]
-    assert [d["name"] for d in payload["opponent_decks"]] == ["Alpha", "Beta"]
-
+    assert [d["name"] for d in payload["opponent_decks"]] == ["Beta", "Alpha"]


### PR DESCRIPTION
Issue #68

要望: 月またぎでデッキ並びが変わって使いづらい → 月を無視して「総対戦数」で並び替えたい

- `/statistics/available-decks` の `my_decks` / `opponent_decks` を（指定month内に登場するデッキ集合は維持しつつ）全期間の対戦数で降順ソート
- `game_mode` が指定されている場合は、そのモード内の総対戦数でソート
- 同数の場合はデッキ名（case-insensitive）で安定化
- ついでに `user_id` でも絞り込み

テスト（コンテナ内）:
- `TEST_DATABASE_URL=sqlite:///./test_statistics.db pytest -q tests/test_statistics_available_decks.py`

※ブランチ削除は確認後に対応します。
