### PR TITLE
feat: 共有統計にアプリ遷移ロゴを追加

### DIFF
--- a/frontend/src/views/SharedStatisticsView.vue
+++ b/frontend/src/views/SharedStatisticsView.vue
@@ -4,7 +4,14 @@
     <v-app-bar app flat color="transparent">
       <v-toolbar-title class="d-flex align-center">
         <v-btn href="/" variant="text" class="logo-link" :ripple="false">
-          <v-icon class="mr-2" color="primary">mdi-chart-bar</v-icon>
+          <v-img
+            src="/favicon.svg"
+            alt="Duel Log"
+            width="28"
+            height="28"
+            class="mr-2"
+            contain
+          />
           <span class="text-h6">Duel Log Shared Statistics</span>
         </v-btn>
       </v-toolbar-title>

--- a/frontend/src/views/__tests__/SharedStatisticsView.test.ts
+++ b/frontend/src/views/__tests__/SharedStatisticsView.test.ts
@@ -57,13 +57,14 @@ describe('SharedStatisticsView.vue', () => {
           VMain: { template: '<div><slot /></div>' },
           VAppBar: {
             template:
-              '<div class="v-app-bar"><div class="v-toolbar-title"><slot /></slot></div></div>',
+              '<div class="v-app-bar"><div class="v-toolbar-title"><slot /></div></div>',
           },
           VContainer: { template: '<div><slot /></div>' },
         },
       },
     });
     expect(wrapper.find('.v-app-bar').exists()).toBe(true);
+    expect(wrapper.find('.logo-link').attributes('href')).toBe('/');
     expect(wrapper.find('.v-toolbar-title').text()).toContain('Duel Log Shared Statistics');
   });
 
@@ -153,7 +154,7 @@ describe('SharedStatisticsView.vue', () => {
           VMain: { template: '<div><slot /></div>' },
           VAppBar: {
             template:
-              '<div class="v-app-bar"><div class="v-toolbar-title"><slot /></slot></div></div>',
+              '<div class="v-app-bar"><div class="v-toolbar-title"><slot /></div></div>',
           },
           VContainer: { template: '<div><slot /></div>' },
         },
@@ -201,7 +202,7 @@ describe('SharedStatisticsView.vue', () => {
           VMain: { template: '<div><slot /></div>' },
           VAppBar: {
             template:
-              '<div class="v-app-bar"><div class="v-toolbar-title"><slot /></slot></div></div>',
+              '<div class="v-app-bar"><div class="v-toolbar-title"><slot /></div></div>',
           },
           VContainer: { template: '<div><slot /></div>' },
         },


### PR DESCRIPTION
Issue #36

- 共有統計ページ上部のロゴリンクを `v-icon` からアプリロゴ（`/favicon.svg`）に変更
- ロゴクリックでメインアプリ（`/`）へ遷移

テスト: `frontend/src/views/__tests__/SharedStatisticsView.test.ts`
