### PR TITLE
feat(backend): add archive merge script

### DIFF
--- a/backend/app/scripts/merge_archived_decks.py
+++ b/backend/app/scripts/merge_archived_decks.py
@@ -5,7 +5,6 @@ import os
 import sys
 from collections import defaultdict
 
-from sqlalchemy import is_
 from sqlalchemy.orm import Session
 
 # Ensure the app path is in the sys.path to allow for absolute imports


### PR DESCRIPTION
This PR introduces a script to merge duplicate archived decks. This script is intended to be run once manually via the Render start command to clean up existing data.