### PR TITLE
fix(frontend): add missing is_admin field in tests and types

### DIFF
--- a/frontend/src/components/layout/AppLayout.vue
+++ b/frontend/src/components/layout/AppLayout.vue
@@ -26,7 +26,7 @@
 import { computed, ref } from 'vue';
 import AppBar from '@/components/layout/AppBar.vue';
 
-type CurrentView = 'dashboard' | 'decks' | 'statistics' | 'profile';
+type CurrentView = 'dashboard' | 'decks' | 'statistics' | 'profile' | 'admin';
 
 interface NavItem {
   name: string;

--- a/frontend/src/stores/__tests__/theme.test.ts
+++ b/frontend/src/stores/__tests__/theme.test.ts
@@ -17,6 +17,7 @@ const createUser = () => ({
   username: 'tester',
   streamer_mode: false,
   theme_preference: 'dark',
+  is_admin: false,
 });
 
 describe('theme store', () => {

--- a/frontend/src/views/__tests__/ProfileView.test.ts
+++ b/frontend/src/views/__tests__/ProfileView.test.ts
@@ -28,6 +28,7 @@ describe('ProfileView.vue', () => {
       username: 'testuser',
       streamer_mode: false,
       theme_preference: 'dark',
+      is_admin: false,
     };
 
     const wrapper = mount(ProfileView, {
@@ -55,6 +56,7 @@ describe('ProfileView.vue', () => {
       username: 'testuser',
       streamer_mode: false,
       theme_preference: 'dark',
+      is_admin: false,
     };
 
     const wrapper = mount(ProfileView, {
@@ -83,6 +85,7 @@ describe('ProfileView.vue', () => {
       username: 'testuser',
       streamer_mode: false,
       theme_preference: 'dark',
+      is_admin: false,
     };
 
     const wrapper = mount(ProfileView, {


### PR DESCRIPTION
## Summary
Fix TypeScript compilation errors in Vercel deployment caused by missing is_admin field in test fixtures and type definitions.

## Changes
- Add `is_admin: false` to `createUser()` in theme.test.ts
- Add `is_admin: false` to all user fixtures in ProfileView.test.ts
- Add `'admin'` to CurrentView type in AppLayout.vue

## Error Fixed
```
error TS2741: Property 'is_admin' is missing in type...
error TS2322: Type '"admin"' is not assignable to type 'CurrentView'.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)