### PR TITLE
fix(backend): add exception chaining in admin router

### DIFF
--- a/backend/app/api/routers/admin.py
+++ b/backend/app/api/routers/admin.py
@@ -79,4 +79,4 @@ def merge_archived_decks(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Error during merge operation: {str(e)}",
-        )
+        ) from e

--- a/frontend/src/views/AdminView.vue
+++ b/frontend/src/views/AdminView.vue
@@ -99,8 +99,12 @@ const executeMerge = async () => {
     successSnackbar.value = true;
   } catch (error: any) {
     console.error('Merge failed:', error);
+    console.error('Error response:', error.response);
+    console.error('Error data:', error.response?.data);
     errorMessage.value =
-      error.response?.data?.detail || 'マージに失敗しました';
+      error.response?.data?.detail ||
+      error.message ||
+      'マージに失敗しました';
     errorSnackbar.value = true;
   } finally {
     merging.value = false;


### PR DESCRIPTION
## Summary
Fix Ruff linting error B904 and improve error logging for admin operations.

## Changes
- Add `from e` to HTTPException in admin.py (fixes B904 linting error)
- Improve error logging in AdminView.vue for better debugging

## Fixes
- CI linting check now passes
- More detailed error information logged to console

🤖 Generated with [Claude Code](https://claude.com/claude-code)