### PR TITLE
fix(backend): use correct field name in merge script

### DIFF
--- a/backend/app/scripts/merge_archived_decks.py
+++ b/backend/app/scripts/merge_archived_decks.py
@@ -55,12 +55,12 @@ def run_merge(db: Session):
             )
 
             # Sort by creation date to find the primary (oldest) deck
-            decks.sort(key=lambda d: d.created_at)
+            decks.sort(key=lambda d: d.createdat)
             primary_deck = decks[0]
             duplicate_decks = decks[1:]
 
             logger.info(
-                f"  Primary deck: ID {primary_deck.id} (Created: {primary_deck.created_at})"
+                f"  Primary deck: ID {primary_deck.id} (Created: {primary_deck.createdat})"
             )
 
             for duplicate_deck in duplicate_decks:


### PR DESCRIPTION
## Summary
Fix 500 Internal Server Error in admin merge operation caused by incorrect field name.

## Error Fixed
```
'Deck' object has no attribute 'created_at'
```

## Changes
- Change `deck.created_at` to `deck.createdat` in merge_archived_decks.py
- The Deck model uses `createdat` (lowercase, no underscore) for timestamps

## Root Cause
The Deck model defines the creation timestamp as `createdat` but the merge script was using `created_at`, causing an AttributeError when trying to sort decks by creation date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)