### PR TITLE
fix(backend): correct opponent_deck_id field name in merge script

### DIFF
--- a/backend/app/scripts/merge_archived_decks.py
+++ b/backend/app/scripts/merge_archived_decks.py
@@ -79,11 +79,10 @@ def run_merge(db: Session):
                 )
 
                 # 2. Update duels where the opponent's deck was the duplicate
-                # Note: 'opponentDeck_id' is the current column name from the schema.
                 duels_as_opponent_deck_count = (
                     db.query(Duel)
-                    .filter(Duel.opponentDeck_id == duplicate_deck.id)
-                    .update({"opponentDeck_id": primary_deck.id})
+                    .filter(Duel.opponent_deck_id == duplicate_deck.id)
+                    .update({"opponent_deck_id": primary_deck.id})
                 )
                 logger.info(
                     f"    - Updated {duels_as_opponent_deck_count} duel(s) (as opponent deck)."


### PR DESCRIPTION
## Summary
Fix second AttributeError in admin merge operation caused by incorrect field name.

## Error Fixed
```
type object 'Duel' has no attribute 'opponentDeck_id'
```

## Changes
- Change `Duel.opponentDeck_id` to `Duel.opponent_deck_id` in merge_archived_decks.py
- Update dictionary key from `"opponentDeck_id"` to `"opponent_deck_id"`
- Remove incorrect comment about schema naming

## Root Cause
The Duel model uses snake_case naming (`opponent_deck_id`) but the merge script was using mixed camelCase/snake_case (`opponentDeck_id`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)