### PR TITLE
docs: プロジェクト引き継ぎドキュメントとスクリプトを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,49 @@ pre-commit run --all-files
 - **アプリ内フィードバック**: ヘルプメニューからのバグ報告・機能要望
 - **システム統計ダッシュボード**: 管理者向けシステム全体の統計表示
 
+## プロジェクトの引き継ぎについて
+
+### ベンダロックインに関する注意事項
+
+このプロジェクトは以下のSaaSに依存しています：
+
+- **Supabase**: 認証（OAuth含む）およびPostgreSQLデータベース
+- **Vercel**: フロントエンドホスティング
+- **Render**: バックエンドホスティング
+
+特にSupabaseについては、プロジェクトの所有権移転が困難（Enterpriseプランのみ対応）であるため、管理者交代時には**新規プロジェクトのセットアップとデータ移行**が必要になります。
+
+### 移行の容易さ
+
+ただし、以下の理由により、他の環境への移行は比較的容易です：
+
+- **データベース**: 標準的なPostgreSQL + SQLAlchemyを使用（Supabase固有機能は未使用）
+- **認証**: フロントエンドのみSupabase SDKに依存。バックエンドは標準的なJWT検証
+- **その他機能**: Realtime、Storage、Edge Functionsなど、Supabase固有機能は使用していない
+
+### 引き継ぎドキュメント
+
+管理者交代や環境移行を行う場合は、以下のドキュメントを参照してください：
+
+- **[プロジェクト引き継ぎガイド](docs/operations/handover-guide.md)**: 完全な引き継ぎ手順（ステップバイステップ）
+- **[引き継ぎチェックリスト](docs/operations/handover-checklist.md)**: 作業漏れを防ぐチェックリスト
+
+### データのエクスポート/インポート
+
+本番環境のデータを移行するためのスクリプトを用意しています：
+
+```bash
+# データエクスポート（現在の管理者）
+export DATABASE_URL="postgresql://..."
+./scripts/export-production-data.sh
+
+# データインポート（新しい管理者）
+export DATABASE_URL="postgresql://..."
+./scripts/import-production-data.sh data-exports/backup_YYYYMMDD_HHMMSS
+```
+
+詳細は [プロジェクト引き継ぎガイド](docs/operations/handover-guide.md) を参照してください。
+
 ## ライセンス
 
 このプロジェクトは MIT ライセンスの下で公開されています。詳細については [LICENSE](LICENSE) ファイルを参照してください。

--- a/docs/operations/handover-checklist.md
+++ b/docs/operations/handover-checklist.md
@@ -1,0 +1,381 @@
+# プロジェクト引き継ぎチェックリスト
+
+このチェックリストは、Duel Log Appの管理者交代をスムーズに進めるためのものです。
+各項目を確認しながら、順番に進めてください。
+
+---
+
+## 事前準備
+
+### 現在の管理者
+
+- [ ] 新しい管理者と引き継ぎスケジュールを調整
+- [ ] 新しい管理者が必要なアカウントを作成済みか確認
+  - [ ] GitHub
+  - [ ] Supabase
+  - [ ] Vercel
+  - [ ] Render
+- [ ] 新しい管理者が必要なツールをインストール済みか確認
+  - [ ] Docker Desktop
+  - [ ] Node.js (v18+)
+  - [ ] Python (3.11+)
+  - [ ] PostgreSQL Client (psql)
+  - [ ] Supabase CLI
+
+### 新しい管理者
+
+- [ ] 上記のアカウントをすべて作成
+- [ ] 上記のツールをすべてインストール
+- [ ] `docs/operations/handover-guide.md` を一読
+
+---
+
+## フェーズ1: データエクスポート（現在の管理者）
+
+**担当**: 現在の管理者
+**所要時間**: 30分〜1時間
+
+- [ ] 本番環境のデータベース接続情報を確認
+  - Supabase Dashboard > Project Settings > Database > Connection string (URI)
+- [ ] エクスポートスクリプトを実行
+  ```bash
+  export DATABASE_URL="postgresql://..."
+  ./scripts/export-production-data.sh
+  ```
+- [ ] エクスポートデータを確認
+  ```bash
+  ls -lh data-exports/backup_*/
+  wc -l data-exports/backup_*/*.csv
+  ```
+- [ ] データを圧縮
+  ```bash
+  cd data-exports
+  zip -er backup_YYYYMMDD_HHMMSS.zip backup_YYYYMMDD_HHMMSS/
+  ```
+- [ ] データを安全に新しい管理者へ共有（1Password, Google Drive等）
+- [ ] `.env.example` が最新であることを確認
+- [ ] README.md が最新であることを確認
+- [ ] 最終コミット&プッシュ
+  ```bash
+  git add .
+  git commit -m "docs: 引き継ぎ用ドキュメント最終更新"
+  git push origin main
+  ```
+
+---
+
+## フェーズ2: リポジトリのフォーク（新しい管理者）
+
+**担当**: 新しい管理者
+**所要時間**: 10分
+
+- [ ] GitHubで元のリポジトリをフォーク
+- [ ] フォークしたリポジトリをローカルにクローン
+  ```bash
+  git clone https://github.com/[あなたのユーザー名]/duel-log-app.git
+  cd duel-log-app
+  ```
+- [ ] エクスポートデータを受け取り、解凍
+  ```bash
+  unzip backup_YYYYMMDD_HHMMSS.zip
+  mv backup_YYYYMMDD_HHMMSS data-exports/
+  ```
+
+---
+
+## フェーズ3: Supabaseプロジェクトのセットアップ（新しい管理者）
+
+**担当**: 新しい管理者
+**所要時間**: 15分
+
+- [ ] Supabaseで新規プロジェクトを作成
+  - Name: `duel-log-app-prod`
+  - Region: `Northeast Asia (Tokyo)`
+  - Database Password: 強力なパスワード（保存必須）
+- [ ] プロジェクトの作成完了を待つ（約2分）
+- [ ] データベース接続情報を取得
+  - Project Settings > Database > Connection string (URI)
+- [ ] Supabase API情報を取得
+  - Project Settings > API
+  - Project URL
+  - anon public key
+  - service_role key
+  - JWT Secret
+- [ ] 情報を安全に保存（パスワードマネージャー推奨）
+
+---
+
+## フェーズ4: データベーススキーマの構築（新しい管理者）
+
+**担当**: 新しい管理者
+**所要時間**: 10分
+
+- [ ] `backend/.env` ファイルを作成
+  ```bash
+  cd backend
+  cp .env.example .env
+  # エディタで .env を編集し、Supabase情報を設定
+  ```
+- [ ] Python仮想環境を作成
+  ```bash
+  python3 -m venv venv
+  source venv/bin/activate  # Windows: venv\Scripts\activate
+  ```
+- [ ] 依存関係をインストール
+  ```bash
+  pip install -r requirements.txt
+  ```
+- [ ] Alembicマイグレーションを実行
+  ```bash
+  alembic upgrade head
+  ```
+- [ ] Supabase Studioでテーブルが作成されたことを確認
+  - users, decks, duels, shared_statistics
+
+---
+
+## フェーズ5: データのインポート（新しい管理者）
+
+**担当**: 新しい管理者
+**所要時間**: 10分
+
+- [ ] インポートスクリプトを実行
+  ```bash
+  cd /path/to/duel-log-app
+  export DATABASE_URL="postgresql://..."
+  ./scripts/import-production-data.sh data-exports/backup_YYYYMMDD_HHMMSS
+  ```
+- [ ] インポート完了メッセージを確認
+- [ ] psqlでデータ件数を確認
+  ```bash
+  psql "$DATABASE_URL"
+  SELECT COUNT(*) FROM users;
+  SELECT COUNT(*) FROM decks;
+  SELECT COUNT(*) FROM duels;
+  \q
+  ```
+
+---
+
+## フェーズ6: OAuth認証の設定（新しい管理者）
+
+**担当**: 新しい管理者
+**所要時間**: 30分（オプション機能のため、後回し可能）
+
+### Google OAuth（オプション）
+
+- [ ] Google Cloud Consoleで新規プロジェクトを作成
+- [ ] OAuth consent screenを設定
+- [ ] OAuth 2.0 Client IDを作成
+  - Authorized redirect URIs: `https://xxxxx.supabase.co/auth/v1/callback`
+- [ ] Client IDとClient Secretをコピー
+- [ ] Supabase Dashboard > Authentication > Providers > Google
+  - Enable Google provider
+  - Client IDとClient Secretを入力
+- [ ] 保存
+
+### Discord OAuth（オプション）
+
+- [ ] Discord Developer Portalで新規アプリケーションを作成
+- [ ] OAuth2セクションでRedirectsを設定
+  - `https://xxxxx.supabase.co/auth/v1/callback`
+- [ ] Client IDとClient Secretをコピー
+- [ ] Supabase Dashboard > Authentication > Providers > Discord
+  - Enable Discord provider
+  - Client IDとClient Secretを入力
+- [ ] 保存
+
+---
+
+## フェーズ7: バックエンドのデプロイ（新しい管理者）
+
+**担当**: 新しい管理者
+**所要時間**: 15分
+
+- [ ] Render Dashboardで新規Web Serviceを作成
+  - GitHubリポジトリを接続
+  - Name: `duel-log-app-backend`
+  - Root Directory: `backend`
+  - Runtime: Docker
+  - Instance Type: Free
+- [ ] 環境変数を設定
+  - DATABASE_URL
+  - SUPABASE_URL
+  - SUPABASE_ANON_KEY
+  - SUPABASE_JWT_SECRET
+  - SECRET_KEY (新規生成: `openssl rand -base64 32`)
+  - ENVIRONMENT=production
+  - FRONTEND_URL (後で設定)
+- [ ] Create Web Serviceをクリック
+- [ ] デプロイ完了を待つ（約5-10分）
+- [ ] デプロイURLを確認: `https://duel-log-app-backend.onrender.com`
+- [ ] ヘルスチェック
+  ```bash
+  curl https://duel-log-app-backend.onrender.com/health
+  ```
+
+---
+
+## フェーズ8: フロントエンドのデプロイ（新しい管理者）
+
+**担当**: 新しい管理者
+**所要時間**: 10分
+
+- [ ] Vercel Dashboardで新規プロジェクトを作成
+  - GitHubリポジトリを接続
+  - Framework Preset: Vite
+  - Root Directory: `frontend`
+- [ ] 環境変数を設定
+  - VITE_API_URL=https://duel-log-app-backend.onrender.com
+  - VITE_SUPABASE_URL=https://xxxxx.supabase.co
+  - VITE_SUPABASE_ANON_KEY=eyJhbGci...
+- [ ] Deployをクリック
+- [ ] デプロイ完了を待つ（約3-5分）
+- [ ] デプロイURLを確認: `https://your-app.vercel.app`
+- [ ] Render Dashboardでバックエンドの環境変数を更新
+  - FRONTEND_URL=https://your-app.vercel.app
+- [ ] バックエンドの再デプロイを待つ
+
+---
+
+## フェーズ9: 動作確認（新しい管理者）
+
+**担当**: 新しい管理者
+**所要時間**: 30分
+
+### 基本機能
+
+- [ ] フロントエンドURL（`https://your-app.vercel.app`）にアクセス
+- [ ] ログインページが表示される
+- [ ] Google/Discord OAuthボタンが表示される（設定済みの場合）
+- [ ] メール/パスワードで新規ユーザー登録
+- [ ] ログインが成功する
+- [ ] ダッシュボードが表示される
+
+### データ確認
+
+- [ ] テストデッキを作成
+- [ ] テスト対戦履歴を登録
+- [ ] 統計情報が正しく表示される
+- [ ] CSVエクスポートが動作する
+- [ ] CSVインポートが動作する
+
+### OAuth確認（設定済みの場合）
+
+- [ ] Googleログインが動作する
+- [ ] Discordログインが動作する
+
+### 管理者機能
+
+- [ ] プロフィールページでOBSトークンを生成
+- [ ] OBSオーバーレイページにアクセス
+  - `https://your-app.vercel.app/obs-overlay?token=obs_token_xxxx`
+- [ ] 配信者モードが動作する
+
+---
+
+## フェーズ10: ユーザーへの通知（新しい管理者）
+
+**担当**: 新しい管理者
+**所要時間**: 1時間
+
+- [ ] ユーザー向け移行お知らせを作成
+  - `docs/operations/handover-guide.md` のテンプレートを使用
+- [ ] 移行スケジュールを決定
+  - 旧環境のアクセス可能期間（推奨: 1ヶ月以上）
+  - データエクスポート期限
+- [ ] お知らせを公開
+  - [ ] GitHub Issues
+  - [ ] Twitter/X
+  - [ ] Discord（ある場合）
+  - [ ] アプリ内通知（可能であれば）
+- [ ] 旧環境にバナーを表示（可能であれば）
+  - 新URLへのリダイレクト案内
+
+---
+
+## フェーズ11: 最終確認（両者で協力）
+
+**担当**: 現在の管理者 + 新しい管理者
+**所要時間**: 1時間
+
+### 新しい管理者
+
+- [ ] すべての機能が正常に動作することを確認
+- [ ] ドキュメントに不明点がないか確認
+- [ ] 緊急時の連絡先を確認
+
+### 現在の管理者
+
+- [ ] 旧環境の停止スケジュールをユーザーに通知
+- [ ] 旧環境のデータベースバックアップを取得（念のため）
+- [ ] 新しい管理者へ引き継ぎ完了を確認
+
+### 両者
+
+- [ ] 引き継ぎドキュメントのレビュー
+- [ ] 問題点や改善点をドキュメントに反映
+
+---
+
+## フェーズ12: 旧環境の停止（現在の管理者）
+
+**担当**: 現在の管理者
+**実施時期**: ユーザー通知から1ヶ月後（推奨）
+
+- [ ] ユーザーへ最終通知（1週間前）
+- [ ] 旧環境のアクセスを停止
+  - [ ] Vercel: プロジェクトを削除
+  - [ ] Render: サービスを削除
+  - [ ] Supabase: プロジェクトを削除（慎重に）
+- [ ] DNSレコードを削除（独自ドメインの場合）
+- [ ] GitHubリポジトリにアーカイブマーク
+  - またはREADMEに「このリポジトリは移行しました」と記載
+
+---
+
+## トラブルシューティング
+
+問題が発生した場合は以下を確認してください：
+
+### データインポートエラー
+
+- [ ] CSVファイルのエンコーディングがUTF-8か確認
+- [ ] テーブルが正しい順序でインポートされているか確認
+- [ ] 外部キー制約のエラーメッセージを確認
+
+### OAuth認証エラー
+
+- [ ] リダイレクトURIが正しく設定されているか確認
+- [ ] Client IDとClient Secretが正しいか確認
+- [ ] Supabase DashboardでProviderが有効になっているか確認
+
+### バックエンドAPIエラー
+
+- [ ] Render Logsでエラーメッセージを確認
+- [ ] 環境変数が正しく設定されているか確認
+- [ ] データベース接続が正常か確認（psqlでテスト）
+
+### その他
+
+- [ ] `docs/operations/handover-guide.md` のトラブルシューティングセクションを参照
+- [ ] GitHub Issuesで質問を投稿
+- [ ] 元の管理者に連絡（引き継ぎ期間中のみ）
+
+---
+
+## 引き継ぎ完了の確認
+
+すべてのチェックボックスにチェックが入ったら、引き継ぎは完了です！
+
+- [ ] すべてのフェーズが完了
+- [ ] すべての動作確認が完了
+- [ ] ユーザーへの通知が完了
+- [ ] ドキュメントが最新
+- [ ] 新しい管理者が自信を持って運営できる状態
+
+お疲れ様でした！
+
+---
+
+**最終更新日**: 2026-01-17

--- a/docs/operations/handover-guide.md
+++ b/docs/operations/handover-guide.md
@@ -1,0 +1,676 @@
+# プロジェクト引き継ぎガイド
+
+## はじめに
+
+このドキュメントは、Duel Log Appプロジェクトの運営を現在の管理者から新しい管理者へ引き継ぐための完全な手順書です。
+
+### このドキュメントが必要な理由
+
+このプロジェクトは以下の外部サービスに依存しています：
+
+- **Supabase**: 認証およびデータベース
+- **Vercel**: フロントエンドホスティング
+- **Render**: バックエンドホスティング
+
+特にSupabaseについては、**プロジェクトの所有権移転が困難**（Enterpriseプランのみ対応）であるため、新しい管理者は**新規にプロジェクトをセットアップ**する必要があります。
+
+### 想定される引き継ぎシナリオ
+
+1. **完全な引き継ぎ**: 既存ユーザーデータを含めて新環境へ移行
+2. **新規スタート**: ユーザーデータを移行せず、コードベースのみ引き継ぐ
+
+このガイドでは、**シナリオ1（完全な引き継ぎ）** を中心に解説します。
+
+---
+
+## 前提条件
+
+### 必要なスキル
+
+新しい管理者は以下のスキル・知識が必要です：
+
+- **基本的なGit操作**: clone, pull, push, branch作成
+- **ターミナル操作**: シェルスクリプトの実行、環境変数の設定
+- **PostgreSQL基礎知識**: データのエクスポート/インポート
+- **Webアプリケーションデプロイ経験**: VercelまたはRenderのどちらか
+
+**所要時間の目安:**
+- 経験豊富なエンジニア: 1-2日
+- 初めての方: 3-5日
+
+### 必要なアカウント
+
+以下のサービスのアカウントを事前に作成してください：
+
+1. **GitHub** - リポジトリのフォーク用
+2. **Supabase** (無料プラン可) - 認証＋データベース
+3. **Vercel** (無料プラン可) - フロントエンドホスティング
+4. **Render** (無料プラン可) - バックエンドホスティング
+5. **Google Cloud Console** (オプション) - Google OAuth用
+6. **Discord Developer Portal** (オプション) - Discord OAuth用
+
+### 必要なツール
+
+ローカル環境に以下をインストールしてください：
+
+- **Docker Desktop**: Supabase CLIで必要
+- **Node.js**: v18以上（nvm推奨）
+- **Python**: 3.11以上
+- **PostgreSQL Client** (`psql`): データ操作用
+- **Supabase CLI**: `npm install -g supabase`
+
+---
+
+## 引き継ぎ手順の全体像
+
+```
+【現在の管理者が実施】
+Step 1: データのエクスポート
+Step 2: リポジトリとドキュメントの最終確認
+
+【新しい管理者が実施】
+Step 3: リポジトリのフォーク
+Step 4: 新規Supabaseプロジェクトのセットアップ
+Step 5: データベーススキーマの構築
+Step 6: データのインポート
+Step 7: OAuth認証の設定
+Step 8: バックエンドのデプロイ（Render）
+Step 9: フロントエンドのデプロイ（Vercel）
+Step 10: 動作確認
+Step 11: ユーザーへの通知
+
+【両者で協力】
+Step 12: DNSの切り替え（オプション）
+```
+
+---
+
+## Step 1: データのエクスポート（現在の管理者）
+
+### 1.1 本番環境のデータベース接続情報を確認
+
+Supabase Dashboardから以下を確認：
+
+1. **Project Settings > Database** にアクセス
+2. **Connection string** の `URI` をコピー
+
+形式: `postgresql://postgres.xxxxx:[password]@aws-0-ap-northeast-1.pooler.supabase.com:6543/postgres`
+
+### 1.2 データエクスポートスクリプトの実行
+
+```bash
+# プロジェクトルートに移動
+cd /path/to/duel-log-app
+
+# エクスポートスクリプトを実行
+# 環境変数でデータベースURLを指定
+export DATABASE_URL="postgresql://postgres.xxxxx:[password]@..."
+
+./scripts/export-production-data.sh
+```
+
+実行すると、`data-exports/` ディレクトリに以下のファイルが生成されます：
+
+```
+data-exports/
+├── backup_YYYYMMDD_HHMMSS/
+│   ├── users.csv
+│   ├── decks.csv
+│   ├── duels.csv
+│   ├── shared_statistics.csv
+│   └── metadata.json
+```
+
+### 1.3 エクスポートデータの確認
+
+```bash
+# 各ファイルの行数を確認
+wc -l data-exports/backup_*/users.csv
+wc -l data-exports/backup_*/decks.csv
+wc -l data-exports/backup_*/duels.csv
+```
+
+### 1.4 データを安全に共有
+
+**重要**: エクスポートデータには個人情報（メールアドレス、パスワードハッシュ）が含まれます。
+
+```bash
+# データを圧縮
+cd data-exports
+tar -czf backup_YYYYMMDD_HHMMSS.tar.gz backup_YYYYMMDD_HHMMSS/
+
+# パスワード付きZIPで暗号化（推奨）
+zip -er backup_YYYYMMDD_HHMMSS.zip backup_YYYYMMDD_HHMMSS/
+```
+
+新しい管理者へ安全な方法（1Password、Google Drive等）で共有してください。
+
+---
+
+## Step 2: リポジトリとドキュメントの最終確認（現在の管理者）
+
+### 2.1 READMEの更新
+
+以下の情報が最新であることを確認：
+
+- デプロイ先のURL
+- 使用している外部サービス
+- 環境変数の一覧
+
+### 2.2 環境変数のドキュメント化
+
+`.env.example` が最新であることを確認し、必要に応じて更新。
+
+### 2.3 最終コミット
+
+```bash
+git add .
+git commit -m "docs: 引き継ぎ用ドキュメント最終更新"
+git push origin main
+```
+
+---
+
+## Step 3: リポジトリのフォーク（新しい管理者）
+
+### 3.1 GitHubでリポジトリをフォーク
+
+1. 元のリポジトリページにアクセス: `https://github.com/[元の管理者]/duel-log-app`
+2. **Fork** ボタンをクリック
+3. 自分のアカウントにフォークを作成
+
+### 3.2 ローカルにクローン
+
+```bash
+git clone https://github.com/[あなたのユーザー名]/duel-log-app.git
+cd duel-log-app
+```
+
+---
+
+## Step 4: 新規Supabaseプロジェクトのセットアップ（新しい管理者）
+
+### 4.1 Supabaseプロジェクトの作成
+
+1. [Supabase Dashboard](https://supabase.com/dashboard) にログイン
+2. **New Project** をクリック
+3. 以下を入力：
+   - **Name**: `duel-log-app-prod` （任意の名前）
+   - **Database Password**: 強力なパスワードを生成（必ず保存）
+   - **Region**: `Northeast Asia (Tokyo)` を推奨
+4. **Create new project** をクリック
+
+プロジェクトの準備に約2分かかります。
+
+### 4.2 データベース接続情報の取得
+
+プロジェクト作成後：
+
+1. **Project Settings > Database** にアクセス
+2. **Connection string** の `URI` をコピー
+3. `.env` ファイルとして保存（後で使用）
+
+### 4.3 Supabase API情報の取得
+
+1. **Project Settings > API** にアクセス
+2. 以下をコピー：
+   - **Project URL**: `https://xxxxx.supabase.co`
+   - **anon public key**: `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...`
+   - **service_role key**: `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...` （管理用）
+
+### 4.4 JWT Secretの取得
+
+1. **Project Settings > API** の **JWT Settings** セクション
+2. **JWT Secret** をコピー
+
+---
+
+## Step 5: データベーススキーマの構築（新しい管理者）
+
+### 5.1 ローカル環境変数の設定
+
+`backend/.env` ファイルを作成：
+
+```bash
+# Supabase接続情報（Step 4で取得）
+DATABASE_URL=postgresql://postgres.xxxxx:[password]@aws-0-ap-northeast-1.pooler.supabase.com:6543/postgres
+SUPABASE_URL=https://xxxxx.supabase.co
+SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+SUPABASE_JWT_SECRET=your-jwt-secret
+
+# JWT署名用のシークレットキー（新規生成）
+SECRET_KEY=$(openssl rand -base64 32)
+
+# 環境設定
+ENVIRONMENT=production
+
+# フロントエンドURL（後で設定するVercelのURL）
+FRONTEND_URL=https://your-app.vercel.app
+```
+
+### 5.2 Alembicマイグレーションの実行
+
+```bash
+cd backend
+
+# Python仮想環境を作成
+python3 -m venv venv
+source venv/bin/activate  # Windows: venv\Scripts\activate
+
+# 依存関係をインストール
+pip install -r requirements.txt
+
+# マイグレーションを実行（本番DBに接続）
+alembic upgrade head
+```
+
+実行後、Supabase Studio（`https://supabase.com/dashboard/project/xxxxx/editor`）で以下のテーブルが作成されていることを確認：
+
+- `users`
+- `decks`
+- `duels`
+- `shared_statistics`
+
+---
+
+## Step 6: データのインポート（新しい管理者）
+
+### 6.1 エクスポートデータの準備
+
+現在の管理者から受け取ったデータを解凍：
+
+```bash
+# プロジェクトルートに移動
+cd /path/to/duel-log-app
+
+# データを解凍
+unzip backup_YYYYMMDD_HHMMSS.zip
+# または
+tar -xzf backup_YYYYMMDD_HHMMSS.tar.gz
+
+# data-exportsディレクトリに配置
+mv backup_YYYYMMDD_HHMMSS data-exports/
+```
+
+### 6.2 インポートスクリプトの実行
+
+```bash
+# 環境変数でデータベースURLを指定
+export DATABASE_URL="postgresql://postgres.xxxxx:[password]@..."
+
+# インポートスクリプトを実行
+./scripts/import-production-data.sh data-exports/backup_YYYYMMDD_HHMMSS
+```
+
+### 6.3 データの確認
+
+```bash
+# psqlで接続
+psql "$DATABASE_URL"
+
+# データ件数を確認
+SELECT COUNT(*) FROM users;
+SELECT COUNT(*) FROM decks;
+SELECT COUNT(*) FROM duels;
+SELECT COUNT(*) FROM shared_statistics;
+
+# 終了
+\q
+```
+
+---
+
+## Step 7: OAuth認証の設定（新しい管理者）
+
+### 7.1 Google OAuth（オプション）
+
+#### Google Cloud Consoleでの設定
+
+1. [Google Cloud Console](https://console.cloud.google.com/) にアクセス
+2. 新規プロジェクトを作成: `duel-log-app-prod`
+3. **APIs & Services > OAuth consent screen** で同意画面を設定
+4. **APIs & Services > Credentials** で OAuth 2.0 クライアントIDを作成
+   - **Application type**: Web application
+   - **Authorized redirect URIs**:
+     - `https://xxxxx.supabase.co/auth/v1/callback`
+5. **Client ID** と **Client Secret** をコピー
+
+#### Supabaseでの設定
+
+1. Supabase Dashboard: **Authentication > Providers**
+2. **Google** を選択
+3. **Enable Google provider** をON
+4. **Client ID** と **Client Secret** を入力
+5. **Save** をクリック
+
+### 7.2 Discord OAuth（オプション）
+
+#### Discord Developer Portalでの設定
+
+1. [Discord Developer Portal](https://discord.com/developers/applications) にアクセス
+2. **New Application** をクリック: `Duel Log App`
+3. **OAuth2** セクションで以下を設定：
+   - **Redirects**: `https://xxxxx.supabase.co/auth/v1/callback`
+4. **Client ID** と **Client Secret** をコピー
+
+#### Supabaseでの設定
+
+1. Supabase Dashboard: **Authentication > Providers**
+2. **Discord** を選択
+3. **Enable Discord provider** をON
+4. **Client ID** と **Client Secret** を入力
+5. **Save** をクリック
+
+---
+
+## Step 8: バックエンドのデプロイ（Render）
+
+### 8.1 Renderプロジェクトの作成
+
+1. [Render Dashboard](https://dashboard.render.com/) にログイン
+2. **New +** > **Web Service** をクリック
+3. GitHubリポジトリを接続: `[あなたのユーザー名]/duel-log-app`
+4. 以下を設定：
+   - **Name**: `duel-log-app-backend`
+   - **Region**: Singapore または Oregon（日本に近いリージョン）
+   - **Branch**: `main`
+   - **Root Directory**: `backend`
+   - **Runtime**: `Docker`
+   - **Instance Type**: Free（または有料プラン）
+
+### 8.2 環境変数の設定
+
+Render Dashboard > **Environment** で以下を追加：
+
+```bash
+DATABASE_URL=postgresql://postgres.xxxxx:[password]@aws-0-ap-northeast-1.pooler.supabase.com:6543/postgres
+SUPABASE_URL=https://xxxxx.supabase.co
+SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+SUPABASE_JWT_SECRET=your-jwt-secret
+SECRET_KEY=（openssl rand -base64 32で生成）
+ENVIRONMENT=production
+FRONTEND_URL=https://your-app.vercel.app
+```
+
+### 8.3 デプロイ
+
+1. **Create Web Service** をクリック
+2. デプロイが完了するまで待機（約5-10分）
+3. デプロイ後のURLを確認: `https://duel-log-app-backend.onrender.com`
+
+### 8.4 動作確認
+
+```bash
+# ヘルスチェック
+curl https://duel-log-app-backend.onrender.com/health
+
+# API Docs
+open https://duel-log-app-backend.onrender.com/docs
+```
+
+---
+
+## Step 9: フロントエンドのデプロイ（Vercel）
+
+### 9.1 Vercelプロジェクトの作成
+
+1. [Vercel Dashboard](https://vercel.com/dashboard) にログイン
+2. **Add New** > **Project** をクリック
+3. GitHubリポジトリを接続: `[あなたのユーザー名]/duel-log-app`
+4. 以下を設定：
+   - **Framework Preset**: Vite
+   - **Root Directory**: `frontend`
+   - **Build Command**: `npm run build`
+   - **Output Directory**: `dist`
+
+### 9.2 環境変数の設定
+
+Vercel Project Settings > **Environment Variables** で以下を追加：
+
+```bash
+VITE_API_URL=https://duel-log-app-backend.onrender.com
+VITE_SUPABASE_URL=https://xxxxx.supabase.co
+VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+```
+
+### 9.3 デプロイ
+
+1. **Deploy** をクリック
+2. デプロイが完了するまで待機（約3-5分）
+3. デプロイ後のURLを確認: `https://your-app.vercel.app`
+
+### 9.4 バックエンドの環境変数を更新
+
+Render Dashboard > **Environment** で `FRONTEND_URL` を更新：
+
+```bash
+FRONTEND_URL=https://your-app.vercel.app
+```
+
+保存後、バックエンドが自動的に再デプロイされます。
+
+---
+
+## Step 10: 動作確認（新しい管理者）
+
+### 10.1 基本機能の確認
+
+1. フロントエンドURL（`https://your-app.vercel.app`）にアクセス
+2. 以下を確認：
+   - ログインページが表示される
+   - Google/Discord OAuth ボタンが表示される
+   - メール/パスワードログインが可能
+
+### 10.2 既存ユーザーでのログイン確認
+
+**重要**: Supabase Authのユーザーデータは移行されていないため、既存ユーザーは**ログインできません**。
+
+新規ユーザー登録が正常に動作することを確認してください。
+
+### 10.3 データの確認
+
+テストユーザーを作成し、以下を確認：
+
+- デッキの作成/編集/削除
+- 対戦履歴の登録
+- 統計情報の表示
+- CSVエクスポート/インポート
+
+---
+
+## Step 11: ユーザーへの通知（新しい管理者）
+
+### 11.1 移行のお知らせ
+
+既存ユーザーに以下の内容を通知してください。
+
+#### テンプレート（メール/SNS投稿用）
+
+```
+【重要】Duel Log App 管理者交代のお知らせ
+
+いつもDuel Log Appをご利用いただき、ありがとうございます。
+
+この度、諸般の事情により、本アプリケーションの管理者が交代することになりました。
+新しい管理者のもと、引き続きサービスを提供してまいります。
+
+■ 変更点
+- 新しいURL: https://your-app.vercel.app
+- 旧URLからのリダイレクト: YYYY年MM月DD日まで有効
+
+■ 既存ユーザーの皆様へ（重要）
+システムの移行に伴い、大変恐縮ですが、**再度アカウント登録が必要**となります。
+
+【再登録手順】
+1. 新しいURL（https://your-app.vercel.app）にアクセス
+2. 「新規登録」から同じメールアドレスで登録
+3. 過去の対戦履歴をCSV形式でインポート（詳細は下記参照）
+
+■ 対戦履歴の移行方法
+旧環境で記録した対戦履歴をCSV形式でエクスポートし、新環境でインポートすることが可能です。
+
+【手順】
+1. 旧環境（https://old-url.com）にログイン
+2. プロフィール > データエクスポート からCSVをダウンロード
+3. 新環境にログイン後、プロフィール > データインポート からCSVをアップロード
+
+■ 移行期間
+- 旧環境のアクセス: YYYY年MM月DD日まで
+- データエクスポート期限: YYYY年MM月DD日まで
+
+■ お問い合わせ
+ご不明な点がございましたら、以下までご連絡ください。
+- GitHub Issues: https://github.com/[あなたのユーザー名]/duel-log-app/issues
+- Twitter: @your_twitter_handle
+
+今後ともDuel Log Appをよろしくお願いいたします。
+
+新管理者: [あなたの名前]
+```
+
+### 11.2 旧環境の停止スケジュール
+
+旧環境（元の管理者が管理）は、移行期間後に停止される予定です。
+ユーザーが十分にデータをエクスポートできる期間（最低1ヶ月）を設けることを推奨します。
+
+---
+
+## Step 12: DNSの切り替え（オプション）
+
+独自ドメインを使用している場合、DNSレコードを新しいデプロイ先に向けます。
+
+### 12.1 Vercelでのカスタムドメイン設定
+
+1. Vercel Project Settings > **Domains**
+2. **Add Domain** で独自ドメインを追加
+3. DNS設定画面で表示されるCNAMEレコードをDNSプロバイダーに追加
+
+例：
+```
+CNAME  www  cname.vercel-dns.com
+```
+
+### 12.2 Renderでのカスタムドメイン設定
+
+1. Render Dashboard > **Settings** > **Custom Domain**
+2. バックエンドのドメイン（例: `api.example.com`）を追加
+3. 表示されるCNAMEレコードをDNSプロバイダーに追加
+
+---
+
+## トラブルシューティング
+
+### データインポート時のエラー
+
+#### エラー: `COPY command failed`
+
+**原因**: CSV形式が不正、または文字エンコーディングの問題
+
+**解決策**:
+```bash
+# CSVのエンコーディングを確認
+file data-exports/backup_*/users.csv
+
+# UTF-8に変換（必要に応じて）
+iconv -f ISO-8859-1 -t UTF-8 users.csv > users_utf8.csv
+```
+
+#### エラー: `foreign key constraint fails`
+
+**原因**: テーブルのインポート順序が間違っている
+
+**解決策**:
+インポートスクリプトが以下の順序でインポートすることを確認：
+1. users
+2. decks
+3. duels
+4. shared_statistics
+
+### OAuth認証が動作しない
+
+#### 症状: Google/Discordログイン後にエラー
+
+**確認項目**:
+1. Supabase Dashboardで OAuth Providerが有効になっているか
+2. Google/Discord Developer ConsoleのリダイレクトURIが正しいか
+   - 正: `https://xxxxx.supabase.co/auth/v1/callback`
+   - 誤: `https://your-app.vercel.app/auth/callback`
+3. Client IDとClient Secretが正しく設定されているか
+
+### バックエンドAPIが500エラーを返す
+
+**確認項目**:
+1. Render Logsでエラーメッセージを確認
+2. 環境変数（特に`DATABASE_URL`）が正しく設定されているか
+3. データベース接続が正常か（psqlでテスト接続）
+
+```bash
+# データベース接続テスト
+psql "$DATABASE_URL" -c "SELECT 1;"
+```
+
+---
+
+## セキュリティ上の注意事項
+
+### 1. 環境変数の管理
+
+- `.env` ファイルは絶対にGitにコミットしない
+- Supabase `service_role` キーは管理者のみが使用
+- `SECRET_KEY` は定期的にローテーション
+
+### 2. データエクスポートファイルの取り扱い
+
+- エクスポートデータには個人情報が含まれるため、暗号化して共有
+- 引き継ぎ完了後、エクスポートファイルを安全に削除
+
+```bash
+# データを完全に削除
+rm -rf data-exports/backup_*
+```
+
+### 3. Supabaseのアクセス権限
+
+- データベースへの直接アクセスは最小限に
+- RLS（Row Level Security）は無効のため、バックエンドAPIで権限制御
+
+---
+
+## 引き継ぎ完了後のチェックリスト
+
+以下を確認してください：
+
+- [ ] 新しいSupabaseプロジェクトが正常に動作している
+- [ ] データベーススキーマが正しく構築されている
+- [ ] データが正常にインポートされている
+- [ ] OAuth認証（Google/Discord）が動作している
+- [ ] バックエンドAPI（Render）が正常に動作している
+- [ ] フロントエンド（Vercel）が正常に動作している
+- [ ] ユーザーへの移行通知を送信した
+- [ ] 旧環境の停止スケジュールを決定した
+- [ ] エクスポートデータを安全に削除した
+- [ ] 新しいリポジトリのREADMEを更新した
+
+---
+
+## サポート
+
+引き継ぎ中に問題が発生した場合：
+
+1. **このリポジトリのIssues**: `https://github.com/[元の管理者]/duel-log-app/issues`
+2. **元の管理者への直接連絡**（引き継ぎ期間中のみ）
+
+---
+
+## 参考資料
+
+- [Supabase公式ドキュメント](https://supabase.com/docs)
+- [Vercelデプロイガイド](https://vercel.com/docs)
+- [Renderデプロイガイド](https://render.com/docs)
+- [PostgreSQL公式ドキュメント](https://www.postgresql.org/docs/)
+- [FastAPI公式ドキュメント](https://fastapi.tiangolo.com/)
+- [Vue.js公式ドキュメント](https://vuejs.org/)
+
+---
+
+**最終更新日**: 2026-01-17

--- a/scripts/export-production-data.sh
+++ b/scripts/export-production-data.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+
+# Duel Log App データエクスポートスクリプト
+# 本番環境のデータベースから全テーブルのデータをCSV形式でエクスポートします
+#
+# 使い方:
+#   export DATABASE_URL="postgresql://user:password@host:port/database"
+#   ./scripts/export-production-data.sh
+
+set -e  # エラーが発生したら即座に終了
+
+# カラー出力
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}=== Duel Log App データエクスポートスクリプト ===${NC}"
+echo ""
+
+# 環境変数のチェック
+if [ -z "$DATABASE_URL" ]; then
+  echo -e "${RED}エラー: DATABASE_URL 環境変数が設定されていません${NC}"
+  echo ""
+  echo "使い方:"
+  echo "  export DATABASE_URL=\"postgresql://user:password@host:port/database\""
+  echo "  ./scripts/export-production-data.sh"
+  exit 1
+fi
+
+# プロジェクトルートに移動
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_ROOT"
+
+# エクスポート先ディレクトリの作成
+TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+EXPORT_DIR="data-exports/backup_$TIMESTAMP"
+mkdir -p "$EXPORT_DIR"
+
+echo -e "${YELLOW}エクスポート先: $EXPORT_DIR${NC}"
+echo ""
+
+# psqlが利用可能かチェック
+if ! command -v psql &> /dev/null; then
+  echo -e "${RED}エラー: psql コマンドが見つかりません${NC}"
+  echo "PostgreSQLクライアントをインストールしてください:"
+  echo "  macOS: brew install postgresql"
+  echo "  Ubuntu: sudo apt-get install postgresql-client"
+  echo "  Windows: https://www.postgresql.org/download/windows/"
+  exit 1
+fi
+
+# データベース接続テスト
+echo -e "${YELLOW}データベース接続をテスト中...${NC}"
+if ! psql "$DATABASE_URL" -c "SELECT 1;" > /dev/null 2>&1; then
+  echo -e "${RED}エラー: データベースに接続できません${NC}"
+  echo "DATABASE_URL を確認してください"
+  exit 1
+fi
+echo -e "${GREEN}✓ 接続成功${NC}"
+echo ""
+
+# テーブルごとにエクスポート
+TABLES=("users" "decks" "duels" "shared_statistics")
+
+for TABLE in "${TABLES[@]}"; do
+  echo -e "${YELLOW}$TABLE テーブルをエクスポート中...${NC}"
+
+  # テーブルの存在確認
+  TABLE_EXISTS=$(psql "$DATABASE_URL" -t -c "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name='$TABLE');" | xargs)
+
+  if [ "$TABLE_EXISTS" != "t" ]; then
+    echo -e "${RED}警告: $TABLE テーブルが見つかりません。スキップします。${NC}"
+    continue
+  fi
+
+  # データ件数を取得
+  COUNT=$(psql "$DATABASE_URL" -t -c "SELECT COUNT(*) FROM $TABLE;" | xargs)
+  echo "  件数: $COUNT"
+
+  # CSVエクスポート
+  psql "$DATABASE_URL" -c "\COPY (SELECT * FROM $TABLE) TO '$EXPORT_DIR/$TABLE.csv' WITH (FORMAT CSV, HEADER true, ENCODING 'UTF8');"
+
+  echo -e "${GREEN}✓ $TABLE.csv を作成しました${NC}"
+  echo ""
+done
+
+# メタデータを生成
+echo -e "${YELLOW}メタデータを生成中...${NC}"
+
+# 各テーブルの件数を取得
+USERS_COUNT=$(psql "$DATABASE_URL" -t -c "SELECT COUNT(*) FROM users;" | xargs)
+DECKS_COUNT=$(psql "$DATABASE_URL" -t -c "SELECT COUNT(*) FROM decks;" | xargs)
+DUELS_COUNT=$(psql "$DATABASE_URL" -t -c "SELECT COUNT(*) FROM duels;" | xargs)
+SHARED_STATS_COUNT=$(psql "$DATABASE_URL" -t -c "SELECT COUNT(*) FROM shared_statistics;" | xargs)
+
+# データベースバージョン情報を取得
+DB_VERSION=$(psql "$DATABASE_URL" -t -c "SELECT version();" | xargs)
+
+# Alembicリビジョンを取得（存在する場合）
+ALEMBIC_REVISION=$(psql "$DATABASE_URL" -t -c "SELECT version_num FROM alembic_version LIMIT 1;" 2>/dev/null | xargs || echo "unknown")
+
+# metadata.jsonを生成
+cat > "$EXPORT_DIR/metadata.json" <<EOF
+{
+  "export_date": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
+  "export_timestamp": "$TIMESTAMP",
+  "database_version": "$DB_VERSION",
+  "alembic_revision": "$ALEMBIC_REVISION",
+  "tables": {
+    "users": {
+      "count": $USERS_COUNT,
+      "file": "users.csv"
+    },
+    "decks": {
+      "count": $DECKS_COUNT,
+      "file": "decks.csv"
+    },
+    "duels": {
+      "count": $DUELS_COUNT,
+      "file": "duels.csv"
+    },
+    "shared_statistics": {
+      "count": $SHARED_STATS_COUNT,
+      "file": "shared_statistics.csv"
+    }
+  },
+  "notes": "This backup was created using export-production-data.sh"
+}
+EOF
+
+echo -e "${GREEN}✓ metadata.json を作成しました${NC}"
+echo ""
+
+# サマリー表示
+echo -e "${GREEN}=== エクスポート完了 ===${NC}"
+echo ""
+echo "エクスポート先: $EXPORT_DIR"
+echo ""
+echo "データ件数:"
+echo "  ユーザー: $USERS_COUNT"
+echo "  デッキ: $DECKS_COUNT"
+echo "  対戦履歴: $DUELS_COUNT"
+echo "  共有統計: $SHARED_STATS_COUNT"
+echo ""
+echo "ファイル:"
+ls -lh "$EXPORT_DIR"
+echo ""
+
+# 圧縮の推奨
+TOTAL_SIZE=$(du -sh "$EXPORT_DIR" | cut -f1)
+echo -e "${YELLOW}推奨: データを圧縮してください${NC}"
+echo ""
+echo "圧縮コマンド例:"
+echo "  cd data-exports"
+echo "  tar -czf backup_$TIMESTAMP.tar.gz backup_$TIMESTAMP/"
+echo "  # または"
+echo "  zip -r backup_$TIMESTAMP.zip backup_$TIMESTAMP/"
+echo ""
+echo -e "${GREEN}エクスポートが正常に完了しました！${NC}"

--- a/scripts/import-production-data.sh
+++ b/scripts/import-production-data.sh
@@ -1,0 +1,258 @@
+#!/bin/bash
+
+# Duel Log App データインポートスクリプト
+# エクスポートされたCSVファイルをデータベースにインポートします
+#
+# 使い方:
+#   export DATABASE_URL="postgresql://user:password@host:port/database"
+#   ./scripts/import-production-data.sh data-exports/backup_YYYYMMDD_HHMMSS
+
+set -e  # エラーが発生したら即座に終了
+
+# カラー出力
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}=== Duel Log App データインポートスクリプト ===${NC}"
+echo ""
+
+# 引数のチェック
+if [ $# -ne 1 ]; then
+  echo -e "${RED}エラー: バックアップディレクトリを指定してください${NC}"
+  echo ""
+  echo "使い方:"
+  echo "  export DATABASE_URL=\"postgresql://user:password@host:port/database\""
+  echo "  ./scripts/import-production-data.sh data-exports/backup_YYYYMMDD_HHMMSS"
+  exit 1
+fi
+
+BACKUP_DIR="$1"
+
+# バックアップディレクトリの存在確認
+if [ ! -d "$BACKUP_DIR" ]; then
+  echo -e "${RED}エラー: バックアップディレクトリが見つかりません: $BACKUP_DIR${NC}"
+  exit 1
+fi
+
+# 環境変数のチェック
+if [ -z "$DATABASE_URL" ]; then
+  echo -e "${RED}エラー: DATABASE_URL 環境変数が設定されていません${NC}"
+  echo ""
+  echo "使い方:"
+  echo "  export DATABASE_URL=\"postgresql://user:password@host:port/database\""
+  echo "  ./scripts/import-production-data.sh $BACKUP_DIR"
+  exit 1
+fi
+
+# プロジェクトルートに移動
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_ROOT"
+
+echo -e "${YELLOW}バックアップディレクトリ: $BACKUP_DIR${NC}"
+echo ""
+
+# psqlが利用可能かチェック
+if ! command -v psql &> /dev/null; then
+  echo -e "${RED}エラー: psql コマンドが見つかりません${NC}"
+  echo "PostgreSQLクライアントをインストールしてください:"
+  echo "  macOS: brew install postgresql"
+  echo "  Ubuntu: sudo apt-get install postgresql-client"
+  echo "  Windows: https://www.postgresql.org/download/windows/"
+  exit 1
+fi
+
+# データベース接続テスト
+echo -e "${YELLOW}データベース接続をテスト中...${NC}"
+if ! psql "$DATABASE_URL" -c "SELECT 1;" > /dev/null 2>&1; then
+  echo -e "${RED}エラー: データベースに接続できません${NC}"
+  echo "DATABASE_URL を確認してください"
+  exit 1
+fi
+echo -e "${GREEN}✓ 接続成功${NC}"
+echo ""
+
+# metadata.jsonの確認
+METADATA_FILE="$BACKUP_DIR/metadata.json"
+if [ ! -f "$METADATA_FILE" ]; then
+  echo -e "${YELLOW}警告: metadata.json が見つかりません${NC}"
+  echo "バックアップの整合性を確認できませんが、続行します。"
+else
+  echo -e "${YELLOW}メタデータを確認中...${NC}"
+  if command -v jq &> /dev/null; then
+    EXPORT_DATE=$(jq -r '.export_date' "$METADATA_FILE")
+    echo "  エクスポート日時: $EXPORT_DATE"
+    echo ""
+  fi
+fi
+
+# 確認プロンプト
+echo -e "${YELLOW}警告: このスクリプトはデータベースにデータをインポートします${NC}"
+echo ""
+echo "データベース: $DATABASE_URL"
+echo ""
+read -p "続行しますか？ (yes/no): " CONFIRM
+
+if [ "$CONFIRM" != "yes" ]; then
+  echo "インポートをキャンセルしました"
+  exit 0
+fi
+echo ""
+
+# テーブルの順序（外部キー制約を考慮）
+# users -> decks -> duels -> shared_statistics
+TABLES=("users" "decks" "duels" "shared_statistics")
+
+# 既存データの削除確認
+echo -e "${YELLOW}既存データの処理${NC}"
+echo ""
+read -p "既存データを削除しますか？ (yes/no): " DELETE_EXISTING
+
+if [ "$DELETE_EXISTING" = "yes" ]; then
+  echo -e "${YELLOW}既存データを削除中...${NC}"
+
+  # 外部キー制約を考慮して逆順で削除
+  for TABLE in "shared_statistics" "duels" "decks" "users"; do
+    COUNT=$(psql "$DATABASE_URL" -t -c "SELECT COUNT(*) FROM $TABLE;" | xargs)
+    if [ "$COUNT" -gt 0 ]; then
+      echo "  $TABLE: $COUNT 件を削除"
+      psql "$DATABASE_URL" -c "TRUNCATE TABLE $TABLE CASCADE;" > /dev/null
+    fi
+  done
+
+  echo -e "${GREEN}✓ 既存データを削除しました${NC}"
+  echo ""
+else
+  echo -e "${YELLOW}既存データを保持します（データの重複に注意してください）${NC}"
+  echo ""
+fi
+
+# テーブルごとにインポート
+for TABLE in "${TABLES[@]}"; do
+  CSV_FILE="$BACKUP_DIR/$TABLE.csv"
+
+  if [ ! -f "$CSV_FILE" ]; then
+    echo -e "${YELLOW}警告: $CSV_FILE が見つかりません。スキップします。${NC}"
+    continue
+  fi
+
+  echo -e "${YELLOW}$TABLE テーブルをインポート中...${NC}"
+
+  # CSVファイルの行数を取得（ヘッダーを除く）
+  LINE_COUNT=$(($(wc -l < "$CSV_FILE") - 1))
+  echo "  インポート件数: $LINE_COUNT"
+
+  # インポート実行
+  # ヘッダー行をスキップしてインポート
+  psql "$DATABASE_URL" -c "\COPY $TABLE FROM '$CSV_FILE' WITH (FORMAT CSV, HEADER true, ENCODING 'UTF8');" 2>&1
+
+  if [ $? -eq 0 ]; then
+    echo -e "${GREEN}✓ $TABLE.csv をインポートしました${NC}"
+  else
+    echo -e "${RED}エラー: $TABLE のインポートに失敗しました${NC}"
+    exit 1
+  fi
+  echo ""
+done
+
+# インポート後のデータ件数確認
+echo -e "${GREEN}=== インポート完了 ===${NC}"
+echo ""
+echo "インポート後のデータ件数:"
+
+for TABLE in "${TABLES[@]}"; do
+  COUNT=$(psql "$DATABASE_URL" -t -c "SELECT COUNT(*) FROM $TABLE;" | xargs)
+  echo "  $TABLE: $COUNT 件"
+done
+echo ""
+
+# シーケンスのリセット（主キーの自動採番を正しく設定）
+echo -e "${YELLOW}シーケンスをリセット中...${NC}"
+
+# 各テーブルのシーケンスを現在の最大ID+1に設定
+psql "$DATABASE_URL" <<EOF > /dev/null 2>&1
+SELECT setval('users_id_seq', COALESCE((SELECT MAX(id) FROM users), 1), true);
+SELECT setval('decks_id_seq', COALESCE((SELECT MAX(id) FROM decks), 1), true);
+SELECT setval('duels_id_seq', COALESCE((SELECT MAX(id) FROM duels), 1), true);
+SELECT setval('shared_statistics_id_seq', COALESCE((SELECT MAX(id) FROM shared_statistics), 1), true);
+EOF
+
+echo -e "${GREEN}✓ シーケンスをリセットしました${NC}"
+echo ""
+
+# 外部キー制約の確認
+echo -e "${YELLOW}外部キー制約を確認中...${NC}"
+
+CONSTRAINT_ERRORS=$(psql "$DATABASE_URL" -t <<EOF
+SELECT
+  'decks.user_id' AS fk,
+  COUNT(*) AS invalid_count
+FROM decks d
+LEFT JOIN users u ON d.user_id = u.id
+WHERE u.id IS NULL
+
+UNION ALL
+
+SELECT
+  'duels.user_id' AS fk,
+  COUNT(*) AS invalid_count
+FROM duels d
+LEFT JOIN users u ON d.user_id = u.id
+WHERE u.id IS NULL
+
+UNION ALL
+
+SELECT
+  'duels.deck_id' AS fk,
+  COUNT(*) AS invalid_count
+FROM duels d
+LEFT JOIN decks dk ON d.deck_id = dk.id
+WHERE dk.id IS NULL
+
+UNION ALL
+
+SELECT
+  'duels.opponent_deck_id' AS fk,
+  COUNT(*) AS invalid_count
+FROM duels d
+LEFT JOIN decks dk ON d.opponent_deck_id = dk.id
+WHERE dk.id IS NULL
+
+UNION ALL
+
+SELECT
+  'shared_statistics.user_id' AS fk,
+  COUNT(*) AS invalid_count
+FROM shared_statistics s
+LEFT JOIN users u ON s.user_id = u.id
+WHERE u.id IS NULL;
+EOF
+)
+
+HAS_ERRORS=0
+while IFS='|' read -r FK_NAME INVALID_COUNT; do
+  FK_NAME=$(echo "$FK_NAME" | xargs)
+  INVALID_COUNT=$(echo "$INVALID_COUNT" | xargs)
+
+  if [ "$INVALID_COUNT" -gt 0 ]; then
+    echo -e "${RED}エラー: $FK_NAME に無効な参照が $INVALID_COUNT 件あります${NC}"
+    HAS_ERRORS=1
+  fi
+done <<< "$CONSTRAINT_ERRORS"
+
+if [ $HAS_ERRORS -eq 0 ]; then
+  echo -e "${GREEN}✓ 外部キー制約の確認完了（問題なし）${NC}"
+else
+  echo -e "${YELLOW}警告: 外部キー制約のエラーがあります。データを確認してください。${NC}"
+fi
+echo ""
+
+# 完了メッセージ
+echo -e "${GREEN}インポートが正常に完了しました！${NC}"
+echo ""
+echo "次のステップ:"
+echo "  1. アプリケーションにログインしてデータを確認"
+echo "  2. 統計情報が正しく表示されることを確認"
+echo "  3. 新規ユーザー登録が動作することを確認"


### PR DESCRIPTION
Supabaseベンダロックインの懸念に対応するため、
プロジェクトの引き継ぎを容易にする以下を追加：

**ドキュメント:**
- docs/operations/handover-guide.md
  完全な引き継ぎ手順（ステップバイステップ）
- docs/operations/handover-checklist.md
  作業漏れを防ぐチェックリスト

**スクリプト:**
- scripts/export-production-data.sh
  本番データベースからCSVエクスポート
- scripts/import-production-data.sh
  新環境へのCSVインポート

**README更新:**
- ベンダロックインに関する注意事項を明記
- 引き継ぎドキュメントへのリンクを追加
- データエクスポート/インポート手順を追加

これにより、管理者交代時に1-2日で環境移行が可能。