### PR TITLE
fix(a11y): add icons to color-dependent status indicators

### DIFF
--- a/frontend/src/components/dashboard/StreakBadge.vue
+++ b/frontend/src/components/dashboard/StreakBadge.vue
@@ -5,6 +5,7 @@
     variant="flat"
     class="streak-badge"
     size="small"
+    :aria-label="streakText"
   >
     <v-icon start size="16">
       {{ streak > 0 ? 'mdi-fire' : 'mdi-snowflake' }}

--- a/frontend/src/components/duel/DuelTable.vue
+++ b/frontend/src/components/duel/DuelTable.vue
@@ -16,7 +16,15 @@
         class="duel-card-compact"
       >
         <!-- 勝敗インジケーター -->
-        <div class="result-indicator" :class="duel.is_win ? 'win' : 'lose'" />
+        <div
+          class="result-indicator"
+          :class="duel.is_win ? 'win' : 'lose'"
+          :aria-label="duel.is_win ? LL?.duels.result.win() : LL?.duels.result.lose()"
+        >
+          <v-icon size="14" color="white">
+            {{ duel.is_win ? 'mdi-check' : 'mdi-close' }}
+          </v-icon>
+        </div>
 
         <!-- メインコンテンツ -->
         <div class="card-content">
@@ -32,10 +40,24 @@
 
           <!-- 2行目: 詳細情報（テキスト表示） -->
           <div class="detail-row">
-            <span class="detail-item" :class="duel.is_going_first ? 'first' : 'second'">
+            <span
+              class="detail-item"
+              :class="duel.is_going_first ? 'first' : 'second'"
+              :aria-label="duel.is_going_first ? LL?.duels.turnOrder.first() : LL?.duels.turnOrder.second()"
+            >
+              <v-icon size="12">
+                {{ duel.is_going_first ? 'mdi-numeric-1-circle' : 'mdi-numeric-2-circle' }}
+              </v-icon>
               {{ duel.is_going_first ? LL?.duels.turnOrder.first() : LL?.duels.turnOrder.second() }}
             </span>
-            <span class="detail-item" :class="duel.won_coin_toss ? 'coin-win' : 'coin-lose'">
+            <span
+              class="detail-item"
+              :class="duel.won_coin_toss ? 'coin-win' : 'coin-lose'"
+              :aria-label="duel.won_coin_toss ? LL?.duels.coinToss.win() : LL?.duels.coinToss.lose()"
+            >
+              <v-icon size="12">
+                {{ duel.won_coin_toss ? 'mdi-alpha-h-circle' : 'mdi-alpha-t-circle' }}
+              </v-icon>
               {{ duel.won_coin_toss ? LL?.duels.coinToss.win() : LL?.duels.coinToss.lose() }}
             </span>
             <!-- ランク/レート/DC表示 -->
@@ -107,7 +129,12 @@
 
     <!-- 勝敗カラム -->
     <template #[`item.is_win`]="{ item }">
-      <v-chip :color="item.is_win ? 'success' : 'error'" variant="flat" class="font-weight-bold">
+      <v-chip
+        :color="item.is_win ? 'success' : 'error'"
+        variant="flat"
+        class="font-weight-bold"
+        :aria-label="item.is_win ? LL?.duels.result.win() : LL?.duels.result.lose()"
+      >
         <v-icon start>
           {{ item.is_win ? 'mdi-check-circle' : 'mdi-close-circle' }}
         </v-icon>
@@ -131,18 +158,22 @@
 
     <!-- コインカラム -->
     <template v-if="!hiddenColumnsSet.has('won_coin_toss')" #[`item.won_coin_toss`]="{ item }">
-      <v-icon :color="item.won_coin_toss ? 'warning' : 'grey'">
-        {{ item.won_coin_toss ? 'mdi-alpha-h-circle' : 'mdi-alpha-t-circle' }}
-      </v-icon>
-      {{ item.won_coin_toss ? LL?.duels.coinToss.win() : LL?.duels.coinToss.lose() }}
+      <span :aria-label="item.won_coin_toss ? LL?.duels.coinToss.win() : LL?.duels.coinToss.lose()">
+        <v-icon :color="item.won_coin_toss ? 'warning' : 'grey'">
+          {{ item.won_coin_toss ? 'mdi-alpha-h-circle' : 'mdi-alpha-t-circle' }}
+        </v-icon>
+        {{ item.won_coin_toss ? LL?.duels.coinToss.win() : LL?.duels.coinToss.lose() }}
+      </span>
     </template>
 
     <!-- 先攻/後攻カラム -->
     <template v-if="!hiddenColumnsSet.has('is_going_first')" #[`item.is_going_first`]="{ item }">
-      <v-icon :color="item.is_going_first ? 'info' : 'purple'">
-        {{ item.is_going_first ? 'mdi-numeric-1-circle' : 'mdi-numeric-2-circle' }}
-      </v-icon>
-      {{ item.is_going_first ? LL?.duels.turnOrder.first() : LL?.duels.turnOrder.second() }}
+      <span :aria-label="item.is_going_first ? LL?.duels.turnOrder.first() : LL?.duels.turnOrder.second()">
+        <v-icon :color="item.is_going_first ? 'info' : 'purple'">
+          {{ item.is_going_first ? 'mdi-numeric-1-circle' : 'mdi-numeric-2-circle' }}
+        </v-icon>
+        {{ item.is_going_first ? LL?.duels.turnOrder.first() : LL?.duels.turnOrder.second() }}
+      </span>
     </template>
 
     <!-- ランク/レートカラム -->
@@ -348,8 +379,11 @@ const tableHeightValue = computed(() => props.tableHeight ?? '70vh');
   border-bottom: 1px solid rgba(128, 128, 128, 0.15);
 
   .result-indicator {
-    width: 4px;
+    width: 24px;
     flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 
     &.win {
       background: rgb(var(--v-theme-success));


### PR DESCRIPTION
## Summary
- Add check/close icons to win/lose indicators in mobile and desktop views
- Add turn order and coin toss icons to mobile detail row
- Add aria-labels for screen readers on all status indicators
- Expand mobile win/lose indicator width to accommodate icons

## Changes Made
### DuelTable.vue
- **Mobile view**: Added visual icons to win/lose indicator (mdi-check/mdi-close)
- **Mobile view**: Added icons to turn order (mdi-numeric-1-circle/mdi-numeric-2-circle)
- **Mobile view**: Added icons to coin toss (mdi-alpha-h-circle/mdi-alpha-t-circle)
- **All views**: Added aria-labels for screen reader accessibility
- **Styling**: Expanded result indicator width from 4px to 24px to accommodate icons

### StreakBadge.vue
- Added aria-label to streak badge for screen reader accessibility

## Test Plan
- [x] Lint passes: `npm run lint`
- [x] Build succeeds: `npm run build`
- [x] Mobile view displays icons correctly
- [x] Desktop view maintains existing icon display
- [x] All status indicators have appropriate aria-labels

## Fixes
Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)