### PR TITLE
fix: バグ修正 (#331, #333) とUI改善

### DIFF
--- a/packages/api/src/db/index.ts
+++ b/packages/api/src/db/index.ts
@@ -10,9 +10,15 @@ const fixedConnectionString = connectionString.includes('pooler.supabase.com:543
   ? connectionString.replace(':5432/', ':6543/')
   : connectionString;
 
+// Local Supabase doesn't use SSL
+const isLocalDb =
+  fixedConnectionString.includes('127.0.0.1') ||
+  fixedConnectionString.includes('localhost') ||
+  fixedConnectionString.includes('supabase_db_');
+
 export const sql = postgres(fixedConnectionString, {
   transform: postgres.camel,
-  ssl: { rejectUnauthorized: false },
+  ssl: isLocalDb ? false : { rejectUnauthorized: false },
   prepare: false,
   idle_timeout: 20,
   max: 3,

--- a/packages/api/src/routes/duels.ts
+++ b/packages/api/src/routes/duels.ts
@@ -188,7 +188,7 @@ export const duelRoutes = new Hono<Env>()
     }
     return c.json({ data: duel });
   })
-  .put('/:id', async (c) => {
+  .patch('/:id', async (c) => {
     const { id } = c.get('user');
     const duelId = c.req.param('id');
     const body = await c.req.json();

--- a/supabase/migrations/20260131000000_normalize_result_values.sql
+++ b/supabase/migrations/20260131000000_normalize_result_values.sql
@@ -1,0 +1,9 @@
+-- Normalize result values to lowercase
+-- Fixes issue #331: Statistics only counting wins
+
+-- Update any uppercase result values to lowercase
+UPDATE duels SET result = LOWER(result) WHERE result != LOWER(result);
+
+-- Add a check constraint to ensure future values are lowercase
+ALTER TABLE duels DROP CONSTRAINT IF EXISTS duels_result_check;
+ALTER TABLE duels ADD CONSTRAINT duels_result_check CHECK (result IN ('win', 'loss'));


### PR DESCRIPTION
## Summary
- #331 統計が勝利数しかカウントしていない問題を修正
- #333 コメントのみの編集が保存されない問題を修正
- ゲームモードタブをヘッダーに統合（UX改善）
- デッキフィルタを当月使用デッキのみに制限
- デッキ削除時のエラーハンドリング改善

## Changes

### Bug Fixes
| Issue | 原因 | 修正 |
|-------|------|------|
| #331 | result値の大文字/小文字混在 | マイグレーションで正規化 + CHECK制約追加 |
| #333 | PUT vs PATCH メソッド不一致 | バックエンドをPATCH対応に変更 |

### Features
- ゲームモードタブをヘッダーに統合（スクロール時も常に表示）
- デッキフィルタドロップダウンを当月使用デッキのみに制限
- デッキ削除エラー時にトースト通知を表示
- ローカル開発環境でのDB接続SSL無効化

## Test plan
- [ ] ログイン後、ダッシュボードでゲームモードタブが常に表示されることを確認
- [ ] デュエルのコメントのみを編集して保存できることを確認
- [ ] 統計画面で勝敗両方がカウントされることを確認
- [ ] 使用中デッキの削除時にエラートーストが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)