### PR TITLE
feat(ui): ヘッダー固定、デッキフィルタ改善、削除エラー通知

### DIFF
--- a/apps/web/src/components/dashboard/DashboardHeader.tsx
+++ b/apps/web/src/components/dashboard/DashboardHeader.tsx
@@ -22,7 +22,10 @@ export function DashboardHeader({
   modeCounts,
 }: Props) {
   return (
-    <div className="space-y-3">
+    <div
+      className="sticky top-0 z-20 -mx-4 px-4 py-3 space-y-3"
+      style={{ background: 'var(--color-bg)' }}
+    >
       <GameModeTabBar value={gameMode} onChange={onGameModeChange} counts={modeCounts} />
       <DateFilterBar
         year={year}

--- a/apps/web/src/components/dashboard/DashboardView.tsx
+++ b/apps/web/src/components/dashboard/DashboardView.tsx
@@ -138,6 +138,7 @@ export function DashboardView() {
           setRangeEnd(modeCounts[gameMode] ?? 30);
         }}
         totalDuels={modeCounts[gameMode] ?? 30}
+        usedDeckIds={new Set(deckUsage.keys())}
       />
 
       {/* Stats Cards */}

--- a/apps/web/src/components/decks/DecksView.tsx
+++ b/apps/web/src/components/decks/DecksView.tsx
@@ -10,11 +10,13 @@ import {
   useUnarchiveDeck,
   useUpdateDeck,
 } from '../../hooks/useDecks.js';
+import { useNotificationStore } from '../../stores/notificationStore.js';
 
 type DeckTab = 'my' | 'opponent';
 
 export function DecksView() {
   const { t } = useTranslation();
+  const { error: showError } = useNotificationStore();
   const [tab, setTab] = useState<DeckTab>('my');
   const [showArchived, setShowArchived] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -33,6 +35,15 @@ export function DecksView() {
   const unarchiveDeck = useUnarchiveDeck();
   const deleteDeck = useDeleteDeck();
   const archiveAll = useArchiveAllDecks();
+
+  const handleDeleteDeck = (deckId: string) => {
+    deleteDeck.mutate(deckId, {
+      onError: () => {
+        showError(t('deck.deleteError'));
+      },
+    });
+    setConfirmDeleteId(null);
+  };
 
   const allDecks = decksData?.data ?? [];
   const filteredDecks = allDecks.filter((d) => {
@@ -372,10 +383,7 @@ export function DecksView() {
                             type="button"
                             className="themed-btn themed-btn-ghost p-1"
                             style={{ color: 'var(--color-error)' }}
-                            onClick={() => {
-                              deleteDeck.mutate(deck.id);
-                              setConfirmDeleteId(null);
-                            }}
+                            onClick={() => handleDeleteDeck(deck.id)}
                           >
                             <svg
                               width="14"

--- a/apps/web/src/components/statistics/StatisticsFilter.tsx
+++ b/apps/web/src/components/statistics/StatisticsFilter.tsx
@@ -14,6 +14,8 @@ type Props = {
   onRangeEndChange: (value: number) => void;
   onReset: () => void;
   totalDuels?: number;
+  /** Set of deck IDs used in the current period - if provided, filter dropdown to only show these */
+  usedDeckIds?: Set<string>;
 };
 
 export function StatisticsFilter({
@@ -28,10 +30,14 @@ export function StatisticsFilter({
   onRangeEndChange,
   onReset,
   totalDuels = 30,
+  usedDeckIds,
 }: Props) {
   const { t } = useTranslation();
 
-  const myDecks = decks.filter((d) => !d.isOpponentDeck);
+  // Filter to my decks, and if usedDeckIds is provided, only show decks that were used
+  const myDecks = decks
+    .filter((d) => !d.isOpponentDeck)
+    .filter((d) => !usedDeckIds || usedDeckIds.has(d.id));
   const sliderMax = Math.max(totalDuels, rangeEnd, 10);
 
   const handleSliderStartChange = useCallback(

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -129,7 +129,8 @@
     "archiveAll": "Archive All",
     "archiveAllConfirm": "Archive all active decks?",
     "generic": "Generic Deck",
-    "genericDesc": "Grouped as 'Other' in statistics"
+    "genericDesc": "Grouped as 'Other' in statistics",
+    "deleteError": "Failed to delete deck. It may be used in duel records."
   },
   "statistics": {
     "title": "Statistics",

--- a/apps/web/src/locales/ja.json
+++ b/apps/web/src/locales/ja.json
@@ -129,7 +129,8 @@
     "archiveAll": "全てアーカイブ",
     "archiveAllConfirm": "全てのアクティブなデッキをアーカイブしますか？",
     "generic": "汎用デッキ",
-    "genericDesc": "統計で「その他」にまとめられます"
+    "genericDesc": "統計で「その他」にまとめられます",
+    "deleteError": "デッキの削除に失敗しました。対戦記録で使用されている可能性があります。"
   },
   "statistics": {
     "title": "統計",

--- a/apps/web/src/locales/ko.json
+++ b/apps/web/src/locales/ko.json
@@ -129,7 +129,8 @@
     "archiveAll": "전체 보관",
     "archiveAllConfirm": "모든 활성 덱을 보관하시겠습니까?",
     "generic": "범용 덱",
-    "genericDesc": "통계에서 '기타'로 그룹됩니다"
+    "genericDesc": "통계에서 '기타'로 그룹됩니다",
+    "deleteError": "덱 삭제에 실패했습니다. 대전 기록에서 사용 중일 수 있습니다."
   },
   "statistics": {
     "title": "통계",


### PR DESCRIPTION
## Summary
PR #334で記載していたUI改善を実装しました。

### 変更内容
- **ゲームモードタブ固定**: スクロール時もヘッダー（GameModeTabBar + DateFilterBar）が常に表示される
- **デッキフィルタ改善**: ドロップダウンを当月使用デッキのみに制限し、選択肢をシンプルに
- **デッキ削除エラー通知**: デッキ削除失敗時（対戦記録で使用中など）にトースト通知を表示

### 技術詳細
- `DashboardHeader`: `sticky top-0 z-20`でスクロール固定
- `StatisticsFilter`: `usedDeckIds` propで使用デッキをフィルタリング
- `DecksView`: `useNotificationStore`でエラー通知表示

## Test plan
- [ ] ダッシュボードでスクロールしてもヘッダーが固定されること
- [ ] デッキフィルタのドロップダウンに使用デッキのみ表示されること
- [ ] 使用中のデッキを削除しようとするとエラートーストが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)