### PR TITLE
perf(db): 接続プールサイズを3から10に増加

### DIFF
--- a/packages/api/src/db/index.ts
+++ b/packages/api/src/db/index.ts
@@ -46,5 +46,5 @@ export const sql = postgres(fixedConnectionString, {
   ssl: isLocalDb ? false : { rejectUnauthorized: false },
   prepare: false,
   idle_timeout: 20,
-  max: 3,
+  max: 10,
 });


### PR DESCRIPTION
## Summary
- DB接続プールサイズを `max: 3` から `max: 10` に増加
- ダッシュボード読み込み時の同時クエリ数（最大9）に対応

## Background
ダッシュボード画面で以下のクエリが同時実行される:
- useDuels × 3回 = 6クエリ
- useOverviewStats = 1クエリ
- useStreaks = 1クエリ
- useDecks = 1クエリ

`max: 3` では接続がキュー待ちになり、レスポンスが遅延していた。

## Test plan
- [ ] ダッシュボード画面の読み込み速度が改善されることを確認
- [ ] Vercelログでレスポンス時間を計測

🤖 Generated with [Claude Code](https://claude.com/claude-code)