### PR TITLE
fix(web): 連続登録時の対戦日時が更新されない問題を修正

### DIFF
--- a/apps/web/src/components/dashboard/DuelFormDialog.tsx
+++ b/apps/web/src/components/dashboard/DuelFormDialog.tsx
@@ -12,6 +12,7 @@ import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useCreateDeck } from '../../hooks/useDecks.js';
 import { useScreenAnalysis } from '../../hooks/useScreenAnalysis.js';
+import { getDueledAtForSubmit } from '../../utils/duel.js';
 import { RANK_DEFINITIONS, getRankLabel } from '../../utils/ranks.js';
 import { DeckCombobox } from './DeckCombobox.js';
 import { ScreenAnalysisPanel } from './ScreenAnalysisPanel.js';
@@ -174,9 +175,10 @@ export function DuelFormDialog({
         setOpponentDeckSelection({ id: finalOpponentDeckId, name: opponentDeckSelection.name });
       }
 
-      onSubmit({ ...data, deckId: finalDeckId, opponentDeckId: finalOpponentDeckId });
+      const dueledAt = getDueledAtForSubmit(editingDuel, data.dueledAt);
+      onSubmit({ ...data, deckId: finalDeckId, opponentDeckId: finalOpponentDeckId, dueledAt });
     },
-    [deckSelection, opponentDeckSelection, createDeck, onSubmit, t],
+    [deckSelection, opponentDeckSelection, createDeck, onSubmit, t, editingDuel],
   );
 
   const handleAutoRegister = useCallback(

--- a/apps/web/src/utils/__tests__/duel.test.ts
+++ b/apps/web/src/utils/__tests__/duel.test.ts
@@ -1,0 +1,80 @@
+import type { Duel } from '@duel-log/shared';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getDueledAtForSubmit } from '../duel.js';
+
+describe('getDueledAtForSubmit', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('新規登録時は送信時点の現在時刻を返す', () => {
+    const submitTime = new Date('2026-02-02T10:30:00.000Z');
+    vi.setSystemTime(submitTime);
+
+    const formDueledAt = '2026-02-02T10:00:00.000Z'; // フォーム初期化時の古い時刻
+
+    const result = getDueledAtForSubmit(null, formDueledAt);
+
+    expect(result).toBe(submitTime.toISOString());
+    expect(result).not.toBe(formDueledAt); // フォームの古い時刻ではない
+  });
+
+  it('新規登録時、連続送信で毎回異なる時刻が返される', () => {
+    // 1回目の送信
+    const submitTime1 = new Date('2026-02-02T10:30:00.000Z');
+    vi.setSystemTime(submitTime1);
+    const result1 = getDueledAtForSubmit(null, '2026-02-02T10:00:00.000Z');
+
+    // 5分後に2回目の送信
+    const submitTime2 = new Date('2026-02-02T10:35:00.000Z');
+    vi.setSystemTime(submitTime2);
+    const result2 = getDueledAtForSubmit(null, '2026-02-02T10:00:00.000Z');
+
+    expect(result1).toBe('2026-02-02T10:30:00.000Z');
+    expect(result2).toBe('2026-02-02T10:35:00.000Z');
+    expect(result1).not.toBe(result2);
+  });
+
+  it('編集時はフォームのdueledAtをそのまま返す', () => {
+    const submitTime = new Date('2026-02-02T10:30:00.000Z');
+    vi.setSystemTime(submitTime);
+
+    const editingDuel: Duel = {
+      id: 'duel-1',
+      userId: 'user-1',
+      deckId: 'deck-1',
+      opponentDeckId: 'opponent-deck-1',
+      result: 'win',
+      gameMode: 'RANK',
+      isFirst: true,
+      wonCoinToss: true,
+      rank: 18,
+      rateValue: null,
+      dcValue: null,
+      memo: null,
+      dueledAt: '2026-01-15T14:30:00.000Z',
+      createdAt: '2026-01-15T14:30:00.000Z',
+      updatedAt: '2026-01-15T14:30:00.000Z',
+    };
+
+    const formDueledAt = '2026-01-15T14:30:00.000Z';
+
+    const result = getDueledAtForSubmit(editingDuel, formDueledAt);
+
+    expect(result).toBe(formDueledAt);
+    expect(result).not.toBe(submitTime.toISOString()); // 現在時刻ではない
+  });
+
+  it('editingDuelがundefinedの場合は新規登録として扱う', () => {
+    const submitTime = new Date('2026-02-02T10:30:00.000Z');
+    vi.setSystemTime(submitTime);
+
+    const result = getDueledAtForSubmit(undefined, '2026-02-02T10:00:00.000Z');
+
+    expect(result).toBe(submitTime.toISOString());
+  });
+});

--- a/apps/web/src/utils/duel.ts
+++ b/apps/web/src/utils/duel.ts
@@ -1,0 +1,18 @@
+import type { Duel } from '@duel-log/shared';
+
+/**
+ * フォーム送信時のdueledAt（対戦日時）を決定する
+ *
+ * - 新規登録時：送信時点の現在時刻を使用（連続登録で時刻が更新されない問題の対策）
+ * - 編集時：フォームの値（元のdueledAt）をそのまま使用
+ *
+ * @param editingDuel - 編集中の対戦データ（新規登録時はnull/undefined）
+ * @param formDueledAt - フォームで設定されたdueledAt
+ * @returns 送信に使用するdueledAt
+ */
+export function getDueledAtForSubmit(
+  editingDuel: Duel | null | undefined,
+  formDueledAt: string,
+): string {
+  return editingDuel ? formDueledAt : new Date().toISOString();
+}


### PR DESCRIPTION
## Summary
- 連続して対戦を登録した際、対戦日時（dueledAt）が最初のフォーム表示時の時刻のまま更新されない問題を修正
- フォーム送信時に現在時刻を取得するユーティリティ関数 `getDueledAtForSubmit` を追加
- 新規登録時は送信時点の時刻、編集時は元の時刻を使用するロジックを明確化

## Test plan
- [x] 単体テスト追加（`apps/web/src/utils/__tests__/duel.test.ts`）
- [ ] 手動テスト：連続して対戦を登録し、各対戦の時刻が異なることを確認
- [ ] 手動テスト：既存対戦の編集時、元の時刻が保持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)