### PR TITLE
fix(api): サービステストの型エラーを修正

### DIFF
--- a/packages/api/src/services/__tests__/admin.test.ts
+++ b/packages/api/src/services/__tests__/admin.test.ts
@@ -25,7 +25,7 @@ describe('admin service', () => {
       const result = await listUsers();
 
       expect(result).toHaveLength(2);
-      expect(result[0].email).toBe('user1@example.com');
+      expect(result[0]!.email).toBe('user1@example.com');
     });
 
     it('returns empty array when no users', async () => {

--- a/packages/api/src/services/__tests__/deck.test.ts
+++ b/packages/api/src/services/__tests__/deck.test.ts
@@ -26,7 +26,7 @@ describe('deck service', () => {
       const result = await listDecks('user-1');
 
       expect(result).toHaveLength(2);
-      expect(result[0].name).toBe('Blue-Eyes');
+      expect(result[0]!.name).toBe('Blue-Eyes');
     });
 
     it('returns empty array when no decks exist', async () => {
@@ -66,10 +66,10 @@ describe('deck service', () => {
       ];
       const { createDeck } = await loadDeckService();
 
-      const result = await createDeck('user-1', { name: 'New Deck' });
+      const result = await createDeck('user-1', { name: 'New Deck', isOpponentDeck: false });
 
-      expect(result.name).toBe('New Deck');
-      expect(result.isGeneric).toBe(false);
+      expect(result!.name).toBe('New Deck');
+      expect(result!.isGeneric).toBe(false);
     });
 
     it('creates an opponent deck', async () => {
@@ -80,7 +80,7 @@ describe('deck service', () => {
 
       const result = await createDeck('user-1', { name: 'Enemy Deck', isOpponentDeck: true });
 
-      expect(result.isOpponentDeck).toBe(true);
+      expect(result!.isOpponentDeck).toBe(true);
     });
 
     it('auto-detects generic deck patterns', async () => {
@@ -90,9 +90,9 @@ describe('deck service', () => {
       ];
       const { createDeck } = await loadDeckService();
 
-      const result = await createDeck('user-1', { name: '不明デッキ' });
+      const result = await createDeck('user-1', { name: '不明デッキ', isOpponentDeck: false });
 
-      expect(result.isGeneric).toBe(true);
+      expect(result!.isGeneric).toBe(true);
     });
   });
 

--- a/packages/api/src/services/__tests__/duel.test.ts
+++ b/packages/api/src/services/__tests__/duel.test.ts
@@ -88,9 +88,9 @@ describe('duel service', () => {
         dueledAt: '2024-01-01T00:00:00Z',
       });
 
-      expect(result.result).toBe('win');
-      expect(result.gameMode).toBe('RANK');
-      expect(result.rank).toBe(10);
+      expect(result!.result).toBe('win');
+      expect(result!.gameMode).toBe('RANK');
+      expect(result!.rank).toBe(10);
     });
 
     it('creates duel with optional fields as null', async () => {
@@ -116,8 +116,8 @@ describe('duel service', () => {
         dueledAt: '2024-01-01T00:00:00Z',
       });
 
-      expect(result.rank).toBeNull();
-      expect(result.memo).toBeNull();
+      expect(result!.rank).toBeNull();
+      expect(result!.memo).toBeNull();
     });
   });
 
@@ -162,8 +162,8 @@ describe('duel service', () => {
       const result = await exportDuels('user-1', {});
 
       expect(result).toHaveLength(2);
-      expect(result[0].deckName).toBe('Blue-Eyes');
-      expect(result[0].opponentDeckName).toBe('Dark Magician');
+      expect(result[0]!.deckName).toBe('Blue-Eyes');
+      expect(result[0]!.opponentDeckName).toBe('Dark Magician');
     });
 
     it('returns empty array when no duels', async () => {


### PR DESCRIPTION
## Summary
- CIのtypecheckステップが直近2回連続で失敗していた問題を修正

## Changes
- `admin.test.ts`: 配列要素アクセスに非nullアサーション追加
- `deck.test.ts`: 同上 + `createDeck`呼び出しに必須の`isOpponentDeck`フィールド追加
- `duel.test.ts`: 配列要素・destructuring結果に非nullアサーション追加

## Test plan
- [x] `pnpm -F @duel-log/api typecheck` パス
- [x] CIで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)