### PR TITLE
fix(web): OBSオーバーレイのデフォルトポーリング間隔を10秒に変更

### DIFF
--- a/apps/web/src/components/streamer/StreamerView.tsx
+++ b/apps/web/src/components/streamer/StreamerView.tsx
@@ -55,7 +55,7 @@ function loadObsSettings(): ObsSettings {
     statsPeriod: 'session',
     theme: 'dark',
     layout: 'grid',
-    refreshInterval: 30,
+    refreshInterval: 10,
     items: [...DEFAULT_ITEMS],
     milestoneGoal: 10,
     recentResultsCount: 10,


### PR DESCRIPTION
## Summary
- OBSオーバーレイのデフォルト更新間隔を30秒→10秒に短縮

## Changes
- `StreamerView.tsx`: `refreshInterval` デフォルト値を `30` → `10` に変更

## Context
デフォルト30秒では対戦記録後の反映が遅く感じるユーザーがいるため短縮。
ユーザーは設定画面で5〜300秒の範囲に自由に変更可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)