### PR TITLE
Release: OBSオーバーレイ デフォルト更新間隔の改善

### DIFF
--- a/apps/web/src/components/streamer/StreamerView.tsx
+++ b/apps/web/src/components/streamer/StreamerView.tsx
@@ -55,7 +55,7 @@ function loadObsSettings(): ObsSettings {
     statsPeriod: 'session',
     theme: 'dark',
     layout: 'grid',
-    refreshInterval: 30,
+    refreshInterval: 10,
     items: [...DEFAULT_ITEMS],
     milestoneGoal: 10,
     recentResultsCount: 10,


### PR DESCRIPTION
## Summary
- OBSオーバーレイのデフォルトポーリング間隔を30秒→10秒に短縮 (#353)

## Test plan
- [x] CI通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)