### PR TITLE
fix(api): getStreaksのウィンドウ関数ネストエラーを修正

### DIFF
--- a/apps/web/src/components/streamer/OBSOverlayView.tsx
+++ b/apps/web/src/components/streamer/OBSOverlayView.tsx
@@ -109,10 +109,10 @@ export function OBSOverlayView() {
       if (!response.ok) {
         const body = await response.json().catch(() => ({}));
         const errCode = (body as { error?: { code?: string } }).error?.code;
-        if (errCode === 'INVALID_TOKEN') {
+        if (errCode === 'INVALID_TOKEN' || errCode === 'UNAUTHORIZED') {
           setError(t('streamer.invalidToken'));
         } else if (!dataRef.current) {
-          setError(t('streamer.invalidToken'));
+          setError(t('streamer.fetchError'));
         }
         return;
       }
@@ -122,7 +122,7 @@ export function OBSOverlayView() {
       setError(null);
     } catch {
       if (!dataRef.current) {
-        setError(t('streamer.invalidToken'));
+        setError(t('streamer.fetchError'));
       }
     }
   }, [settings, t]);

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -200,6 +200,7 @@
     "totalDuels": "Total Duels",
     "currentDeck": "Current Deck",
     "invalidToken": "Invalid token",
+    "fetchError": "Failed to fetch data",
     "tokenExpired": "This link has expired",
     "layoutGrid": "Grid",
     "layoutHorizontal": "Horizontal",

--- a/apps/web/src/locales/ja.json
+++ b/apps/web/src/locales/ja.json
@@ -200,6 +200,7 @@
     "totalDuels": "総対戦数",
     "currentDeck": "使用デッキ",
     "invalidToken": "無効なトークンです",
+    "fetchError": "データの取得に失敗しました",
     "tokenExpired": "このリンクは期限切れです",
     "layoutGrid": "グリッド",
     "layoutHorizontal": "横並び",

--- a/apps/web/src/locales/ko.json
+++ b/apps/web/src/locales/ko.json
@@ -200,6 +200,7 @@
     "totalDuels": "총 대전 수",
     "currentDeck": "사용 덱",
     "invalidToken": "유효하지 않은 토큰",
+    "fetchError": "데이터를 가져오지 못했습니다",
     "tokenExpired": "이 링크는 만료되었습니다",
     "layoutGrid": "그리드",
     "layoutHorizontal": "가로",

--- a/packages/api/src/services/statistics.ts
+++ b/packages/api/src/services/statistics.ts
@@ -164,6 +164,8 @@ export async function getStreaks(userId: string, filter: StatisticsFilter): Prom
   const where = buildConditions(userId, filter);
 
   // SQLのWindow関数で連勝/連敗を計算（全データ取得を回避）
+  // NOTE: PostgreSQLではウィンドウ関数のネストが禁止されているため、
+  // LAGとSUMを別CTEに分離する必要がある
   const [result] = await sql<
     {
       currentStreak: number;
@@ -179,16 +181,22 @@ export async function getStreaks(userId: string, filter: StatisticsFilter): Prom
       FROM duels d
       WHERE ${where}
     ),
+    duels_with_lag AS (
+      SELECT
+        result,
+        rn,
+        LAG(result) OVER (ORDER BY rn) as prev_result
+      FROM ordered_duels
+    ),
     streak_groups AS (
       SELECT
         result,
         rn,
         SUM(CASE
-          WHEN result != LAG(result) OVER (ORDER BY rn)
-            OR LAG(result) OVER (ORDER BY rn) IS NULL
+          WHEN result != prev_result OR prev_result IS NULL
           THEN 1 ELSE 0
         END) OVER (ORDER BY rn) as grp
-      FROM ordered_duels
+      FROM duels_with_lag
     ),
     streak_counts AS (
       SELECT


### PR DESCRIPTION
## Summary
- `getStreaks()` の SQL で `LAG()` を `SUM() OVER()` 内にネストしていたため `PostgresError: window function calls cannot be nested` が発生していた
- OBS オーバーレイが初回フェッチ失敗時に全エラーを「無効なトークン」と誤表示していた問題を修正

## Changes
- `packages/api/src/services/statistics.ts`: `LAG()` を別CTE (`duels_with_lag`) に分離し、ウィンドウ関数のネストを解消
- `apps/web/src/components/streamer/OBSOverlayView.tsx`: トークンエラーとサーバーエラーを区別して表示
- `apps/web/src/locales/{ja,en,ko}.json`: `streamer.fetchError` 翻訳キーを追加

## Test plan
- [ ] OBS オーバーレイが正常にデータ取得できることを確認
- [ ] `/api/statistics/streaks` が 500 でなく正常レスポンスを返すことを確認
- [ ] 無効なトークンでアクセス時に「無効なトークン」エラーが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)