### PR TITLE
fix: 新規登録後に相手デッキ選択をリセット

### DIFF
--- a/apps/web/src/components/dashboard/DuelFormDialog.tsx
+++ b/apps/web/src/components/dashboard/DuelFormDialog.tsx
@@ -195,6 +195,12 @@ export function DuelFormDialog({
 
       const dueledAt = getDueledAtForSubmit(editingDuel, data.dueledAt);
       onSubmit({ ...data, deckId: finalDeckId, opponentDeckId: finalOpponentDeckId, dueledAt });
+
+      // Reset opponent deck selection after submission (new registration only)
+      if (!editingDuel) {
+        setOpponentDeckSelection({ id: '', name: '' });
+        setValue('opponentDeckId', '00000000-0000-0000-0000-000000000000');
+      }
     },
     [deckSelection, opponentDeckSelection, createDeck, onSubmit, t, editingDuel],
   );


### PR DESCRIPTION
## Summary
- 新規登録完了後、相手デッキフィールドが入力値のまま残っていたのを修正
- 送信後に `opponentDeckSelection` を空欄にリセットするように変更
- 編集時はリセットしない（既存の動作を維持）

## Test plan
- [ ] 新規登録後、相手デッキが空欄になることを確認
- [ ] 自分のデッキは維持されることを確認
- [ ] 編集時は既存のデッキが表示されたままであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)