### PR TITLE
fix: デッキ選択がバックグラウンド再取得でリセットされる問題を修正

### DIFF
--- a/apps/web/src/components/dashboard/DuelFormDialog.tsx
+++ b/apps/web/src/components/dashboard/DuelFormDialog.tsx
@@ -150,9 +150,7 @@ export function DuelFormDialog({
         deckId: deck?.id ?? '00000000-0000-0000-0000-000000000000',
         opponentDeckId: '00000000-0000-0000-0000-000000000000',
       });
-      setDeckSelection(
-        deck ? { id: deck.id, name: deck.name } : { id: '', name: '' },
-      );
+      setDeckSelection(deck ? { id: deck.id, name: deck.name } : { id: '', name: '' });
       setOpponentDeckSelection({ id: '', name: '' });
     }
     // decks/defaultDeck are accessed via refs to avoid resetting user's


### PR DESCRIPTION
## Summary
- useEffectの依存配列から `decks`/`defaultDeck` のオブジェクト参照を除去
- `useRef` 経由でアクセスし、`defaultDeck?.id` のみを依存に変更
- バックグラウンドrefetchやデッキ作成後のクエリ無効化でユーザーの選択が上書きされなくなる

## Test plan
- [ ] デッキを選択後、しばらく待ってから登録しても選択したデッキで登録されること
- [ ] 新規デッキ作成後、次の登録でデフォルトデッキに戻らないこと
- [ ] 編集モードで正しいデッキが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)