### PR TITLE
fix: デッキ入力リロード・CSV export 500・フィードバック送信失敗を修正 (#371)

### DIFF
--- a/api/[[...route]].js
+++ b/api/[[...route]].js
@@ -10592,11 +10592,11 @@ async function deleteDuel(userId, duelId) {
 async function exportDuels(userId, filter) {
   const where = buildConditions(userId, filter);
   const result = await sql`
-    SELECT d.*, dk.name AS "deckName", odk.name AS "opponentDeckName"
+    SELECT d.*, COALESCE(dk.name, '') AS "deckName", COALESCE(odk.name, '') AS "opponentDeckName"
     FROM duels d
-    JOIN decks dk ON d.deck_id = dk.id
-    JOIN decks odk ON d.opponent_deck_id = odk.id
-    WHERE ${where}
+    LEFT JOIN decks dk ON d.deck_id = dk.id
+    LEFT JOIN decks odk ON d.opponent_deck_id = odk.id
+    WHERE d.id IN (SELECT id FROM duels WHERE ${where})
     ORDER BY d.dueled_at ASC
   `;
   return Array.from(result);
@@ -10884,6 +10884,12 @@ var feedbackSchema = external_exports.object({
   type: external_exports.enum(["bug", "feature", "improvement", "other"]),
   title: external_exports.string().min(1).max(200),
   body: external_exports.string().min(1).max(5e3),
+  // バグ報告用フィールド
+  steps: external_exports.string().max(5e3).optional(),
+  expected: external_exports.string().max(2e3).optional(),
+  actual: external_exports.string().max(2e3).optional(),
+  // 機能要望用フィールド
+  useCase: external_exports.string().max(2e3).optional(),
   // クライアント環境情報（オプション）
   userAgent: external_exports.string().optional(),
   platform: external_exports.string().optional(),
@@ -10910,10 +10916,22 @@ var feedbackRoutes = new Hono2().post("/", async (c) => {
       data.screenSize && `**Screen:** ${data.screenSize}`,
       data.language && `**Language:** ${data.language}`
     ].filter(Boolean).join("\n");
+    const extraSections = [
+      data.steps && `### Reproduction Steps
+${data.steps}`,
+      data.expected && `### Expected
+${data.expected}`,
+      data.actual && `### Actual
+${data.actual}`,
+      data.useCase && `### Use Case
+${data.useCase}`
+    ].filter(Boolean).join("\n\n");
     const issueBody = `**Type:** ${data.type}
 **User ID:** ${id}
 
-${data.body}${envInfo ? `
+${data.body}${extraSections ? `
+
+${extraSections}` : ""}${envInfo ? `
 
 ---
 ### Environment

--- a/apps/web/src/components/dashboard/DuelFormDialog.tsx
+++ b/apps/web/src/components/dashboard/DuelFormDialog.tsx
@@ -9,7 +9,7 @@ import {
 } from '@duel-log/shared';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useQuery } from '@tanstack/react-query';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useCreateDeck } from '../../hooks/useDecks.js';
@@ -52,20 +52,28 @@ export function DuelFormDialog({
   lastUsedDeckId,
 }: Props) {
   const { t } = useTranslation();
-  const myDecks = decks
-    .filter((d) => !d.isOpponentDeck && d.active)
-    .sort((a, b) => {
-      const usageA = deckUsage?.get(a.id) ?? 0;
-      const usageB = deckUsage?.get(b.id) ?? 0;
-      return usageB - usageA;
-    });
-  const opponentDecks = decks
-    .filter((d) => d.isOpponentDeck && d.active)
-    .sort((a, b) => {
-      const usageA = opponentDeckUsage?.get(a.id) ?? 0;
-      const usageB = opponentDeckUsage?.get(b.id) ?? 0;
-      return usageB - usageA;
-    });
+  const myDecks = useMemo(
+    () =>
+      decks
+        .filter((d) => !d.isOpponentDeck && d.active)
+        .sort((a, b) => {
+          const usageA = deckUsage?.get(a.id) ?? 0;
+          const usageB = deckUsage?.get(b.id) ?? 0;
+          return usageB - usageA;
+        }),
+    [decks, deckUsage],
+  );
+  const opponentDecks = useMemo(
+    () =>
+      decks
+        .filter((d) => d.isOpponentDeck && d.active)
+        .sort((a, b) => {
+          const usageA = opponentDeckUsage?.get(a.id) ?? 0;
+          const usageB = opponentDeckUsage?.get(b.id) ?? 0;
+          return usageB - usageA;
+        }),
+    [decks, opponentDeckUsage],
+  );
   const defaultDeck =
     (lastUsedDeckId && myDecks.find((d) => d.id === lastUsedDeckId)) || myDecks[0];
   const decksRef = useRef(decks);

--- a/packages/api/src/routes/feedback.ts
+++ b/packages/api/src/routes/feedback.ts
@@ -8,6 +8,12 @@ const feedbackSchema = z.object({
   type: z.enum(['bug', 'feature', 'improvement', 'other']),
   title: z.string().min(1).max(200),
   body: z.string().min(1).max(5000),
+  // バグ報告用フィールド
+  steps: z.string().max(5000).optional(),
+  expected: z.string().max(2000).optional(),
+  actual: z.string().max(2000).optional(),
+  // 機能要望用フィールド
+  useCase: z.string().max(2000).optional(),
   // クライアント環境情報（オプション）
   userAgent: z.string().optional(),
   platform: z.string().optional(),
@@ -42,7 +48,16 @@ export const feedbackRoutes = new Hono<Env>().post('/', async (c) => {
       .filter(Boolean)
       .join('\n');
 
-    const issueBody = `**Type:** ${data.type}\n**User ID:** ${id}\n\n${data.body}${envInfo ? `\n\n---\n### Environment\n${envInfo}` : ''}`;
+    const extraSections = [
+      data.steps && `### Reproduction Steps\n${data.steps}`,
+      data.expected && `### Expected\n${data.expected}`,
+      data.actual && `### Actual\n${data.actual}`,
+      data.useCase && `### Use Case\n${data.useCase}`,
+    ]
+      .filter(Boolean)
+      .join('\n\n');
+
+    const issueBody = `**Type:** ${data.type}\n**User ID:** ${id}\n\n${data.body}${extraSections ? `\n\n${extraSections}` : ''}${envInfo ? `\n\n---\n### Environment\n${envInfo}` : ''}`;
 
     const response = await fetch(`https://api.github.com/repos/${githubRepo}/issues`, {
       method: 'POST',

--- a/packages/api/src/services/duel.ts
+++ b/packages/api/src/services/duel.ts
@@ -124,11 +124,11 @@ export async function exportDuels(
   const where = buildConditions(userId, filter);
 
   const result = await sql<ExportDuelRow[]>`
-    SELECT d.*, dk.name AS "deckName", odk.name AS "opponentDeckName"
+    SELECT d.*, COALESCE(dk.name, '') AS "deckName", COALESCE(odk.name, '') AS "opponentDeckName"
     FROM duels d
-    JOIN decks dk ON d.deck_id = dk.id
-    JOIN decks odk ON d.opponent_deck_id = odk.id
-    WHERE ${where}
+    LEFT JOIN decks dk ON d.deck_id = dk.id
+    LEFT JOIN decks odk ON d.opponent_deck_id = odk.id
+    WHERE d.id IN (SELECT id FROM duels WHERE ${where})
     ORDER BY d.dueled_at ASC
   `;
   return Array.from(result);


### PR DESCRIPTION
## Summary
- デッキ入力欄（対戦デッキ・使用デッキ）がバックグラウンド再取得時にリロードされる問題を修正
- CSV出力 API の 500 エラー（JOINによるカラム名曖昧性）を修正
- フィードバック送信時に steps/expected/actual/useCase が失われる問題を修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)