### PR TITLE
fix: 新規登録後にメモ欄がクリアされない不具合を修正

### DIFF
--- a/apps/web/src/components/dashboard/DuelFormDialog.tsx
+++ b/apps/web/src/components/dashboard/DuelFormDialog.tsx
@@ -222,6 +222,7 @@ export function DuelFormDialog({
         setValue('wonCoinToss', defaultIsFirst);
         setValue('isFirst', defaultIsFirst);
         setValue('result', 'win');
+        setValue('memo', '');
       }
     },
     [


### PR DESCRIPTION
## Summary
- 新規登録後のフォームリセット処理で `memo` フィールドの初期化が漏れていたのを修正
- `setValue('memo', '')` を追加

## Test plan
- [ ] メモ付きで対戦を新規登録後、メモ欄が空になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)