### PR TITLE
fix: 新規登録後にメモ欄がクリアされない不具合を修正 (#376)

### DIFF
--- a/apps/web/src/components/dashboard/DuelFormDialog.tsx
+++ b/apps/web/src/components/dashboard/DuelFormDialog.tsx
@@ -222,6 +222,7 @@ export function DuelFormDialog({
         setValue('wonCoinToss', defaultIsFirst);
         setValue('isFirst', defaultIsFirst);
         setValue('result', 'win');
+        setValue('memo', '');
       }
     },
     [


### PR DESCRIPTION
## Summary
- 新規登録後のフォームリセット処理で `memo` フィールドの初期化漏れを修正

Includes: #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)