### PR TITLE
DLA-11 feat: フィードバック form を Plane Intake に切り替え

### DIFF
--- a/packages/api/src/routes/feedback.ts
+++ b/packages/api/src/routes/feedback.ts
@@ -8,18 +8,23 @@ const feedbackSchema = z.object({
   type: z.enum(['bug', 'feature', 'improvement', 'other']),
   title: z.string().min(1).max(200),
   body: z.string().min(1).max(5000),
-  // バグ報告用フィールド
   steps: z.string().max(5000).optional(),
   expected: z.string().max(2000).optional(),
   actual: z.string().max(2000).optional(),
-  // 機能要望用フィールド
   useCase: z.string().max(2000).optional(),
-  // クライアント環境情報（オプション）
   userAgent: z.string().optional(),
   platform: z.string().optional(),
   screenSize: z.string().optional(),
   language: z.string().optional(),
 });
+
+const typeToPriority = (type: z.infer<typeof feedbackSchema>['type']): 'high' | 'medium' =>
+  type === 'bug' ? 'high' : 'medium';
+
+const escapeHtml = (s: string): string =>
+  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+const nl2br = (s: string): string => escapeHtml(s).replace(/\n/g, '<br>');
 
 export const feedbackRoutes = new Hono<Env>().post('/', async (c) => {
   try {
@@ -27,54 +32,68 @@ export const feedbackRoutes = new Hono<Env>().post('/', async (c) => {
     const rawBody = await c.req.json();
     const data = feedbackSchema.parse(rawBody);
 
-    const githubToken = process.env.GITHUB_TOKEN;
-    const githubRepo = process.env.GITHUB_FEEDBACK_REPO;
+    const planeToken = process.env.PLANE_API_TOKEN;
+    const planeProjectId = process.env.PLANE_PROJECT_ID;
+    const planeWorkspace = process.env.PLANE_WORKSPACE_SLUG ?? 'codenica';
+    const planeBaseUrl = process.env.PLANE_BASE_URL ?? 'https://plane.codenica.dev';
 
-    if (!githubToken || !githubRepo) {
-      console.error('Feedback config missing:', { hasToken: !!githubToken, hasRepo: !!githubRepo });
+    if (!planeToken || !planeProjectId) {
+      console.error('Feedback config missing:', {
+        hasToken: !!planeToken,
+        hasProject: !!planeProjectId,
+      });
       return c.json(
         { error: { code: 'INTERNAL_ERROR', message: 'Feedback system not configured' } },
         500,
       );
     }
 
-    // 環境情報セクションを構築（メールは含めない）
-    const envInfo = [
-      data.userAgent && `**User Agent:** ${data.userAgent}`,
-      data.platform && `**Platform:** ${data.platform}`,
-      data.screenSize && `**Screen:** ${data.screenSize}`,
-      data.language && `**Language:** ${data.language}`,
+    const envItems = [
+      data.userAgent && `<li><strong>User Agent:</strong> ${escapeHtml(data.userAgent)}</li>`,
+      data.platform && `<li><strong>Platform:</strong> ${escapeHtml(data.platform)}</li>`,
+      data.screenSize && `<li><strong>Screen:</strong> ${escapeHtml(data.screenSize)}</li>`,
+      data.language && `<li><strong>Language:</strong> ${escapeHtml(data.language)}</li>`,
     ]
       .filter(Boolean)
-      .join('\n');
+      .join('');
 
     const extraSections = [
-      data.steps && `### Reproduction Steps\n${data.steps}`,
-      data.expected && `### Expected\n${data.expected}`,
-      data.actual && `### Actual\n${data.actual}`,
-      data.useCase && `### Use Case\n${data.useCase}`,
+      data.steps && `<h3>Reproduction Steps</h3><p>${nl2br(data.steps)}</p>`,
+      data.expected && `<h3>Expected</h3><p>${nl2br(data.expected)}</p>`,
+      data.actual && `<h3>Actual</h3><p>${nl2br(data.actual)}</p>`,
+      data.useCase && `<h3>Use Case</h3><p>${nl2br(data.useCase)}</p>`,
     ]
       .filter(Boolean)
-      .join('\n\n');
+      .join('');
 
-    const issueBody = `**Type:** ${data.type}\n**User ID:** ${id}\n\n${data.body}${extraSections ? `\n\n${extraSections}` : ''}${envInfo ? `\n\n---\n### Environment\n${envInfo}` : ''}`;
+    const descriptionHtml =
+      `<p><strong>Type:</strong> ${escapeHtml(data.type)}<br>` +
+      `<strong>User ID:</strong> ${escapeHtml(id)}</p>` +
+      `<p>${nl2br(data.body)}</p>` +
+      extraSections +
+      (envItems ? `<hr><h3>Environment</h3><ul>${envItems}</ul>` : '');
 
-    const response = await fetch(`https://api.github.com/repos/${githubRepo}/issues`, {
-      method: 'POST',
-      headers: {
-        Authorization: `token ${githubToken}`,
-        'Content-Type': 'application/json',
+    const response = await fetch(
+      `${planeBaseUrl}/api/v1/workspaces/${planeWorkspace}/projects/${planeProjectId}/intake-issues/`,
+      {
+        method: 'POST',
+        headers: {
+          'X-API-Key': planeToken,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          issue: {
+            name: `[${data.type}] ${data.title}`,
+            description_html: descriptionHtml,
+            priority: typeToPriority(data.type),
+          },
+        }),
       },
-      body: JSON.stringify({
-        title: `[${data.type}] ${data.title}`,
-        body: issueBody,
-        labels: ['user-feedback', data.type],
-      }),
-    });
+    );
 
     if (!response.ok) {
       const errorText = await response.text();
-      console.error('GitHub API error:', response.status, errorText);
+      console.error('Plane intake API error:', response.status, errorText);
       return c.json(
         { error: { code: 'INTERNAL_ERROR', message: 'Failed to submit feedback' } },
         500,


### PR DESCRIPTION
## Summary

- アプリ内フィードバック form (`/api/feedback`) の投稿先を GitHub Issues API → **Plane Intake API** (DLA project) に変更
- GitHub Issues 一本化方針 (2026-05-17) に伴い、 新規 user feedback の受け口が宙に浮くのを塞ぐ
- frontend (`apps/web/src/components/feedback/FeedbackView.tsx`) は変更不要 (= 同じ payload schema)

## 変更点

- `packages/api/src/routes/feedback.ts`
  - HTTP 先: `api.github.com/repos/{repo}/issues` → `plane.codenica.dev/api/v1/workspaces/codenica/projects/{project_id}/intake-issues/`
  - 認証ヘッダー: `Authorization: token ...` → `X-API-Key: plane_api_...`
  - Body: markdown → `description_html` (Plane が HTML 期待)
  - priority マッピング: bug → high / その他 → medium
  - Type 情報は description 内に `<strong>Type:</strong> ...` で保持

## env vars (codenica-vps `secrets.enc.env` に追加済)

- `PLANE_API_TOKEN` — Plane service token (label: `duel-log-app-feedback-prod`)
- `PLANE_PROJECT_ID` = `d35f178c-4d31-4616-be11-a74c6f1b12db`
- `PLANE_WORKSPACE_SLUG` (= optional、 default `codenica`)
- `PLANE_BASE_URL` (= optional、 default `https://plane.codenica.dev`)

旧 `GITHUB_TOKEN` / `GITHUB_FEEDBACK_REPO` は今後削除可 (= 他で参照されていないか確認後)。

## Plane

- Issue: DLA-11 — https://plane.codenica.dev/codenica/projects/d35f178c-4d31-4616-be11-a74c6f1b12db/issues/7496aa02-7dec-40b0-badb-705c7cb25729

## Test plan

- [ ] merge 後、 deploy.yml が main push を拾って image build + push する
- [ ] codenica-vps で `up.sh` が新 image を pull + restart する (= deploy.yml 内で実行)
- [ ] 本番 `/api/feedback` に POST して Plane DLA Intake に届くか確認
- [ ] DLA project の Intake (triage) tab で受信を視認
- [ ] エラー時に 500 が返ること (= ENV 未設定や Plane API 不通)