### PR TITLE
DLA-13 fix: DATABASE_SSL=disable env を DB driver に伝える regression を修正

### DIFF
--- a/packages/api/src/db/index.ts
+++ b/packages/api/src/db/index.ts
@@ -12,10 +12,11 @@ const socketMatch = connectionString.match(/[?&]host=([^&]+)/);
 const socketPath = socketMatch?.[1];
 
 const isLocal = /127\.0\.0\.1|localhost/.test(connectionString);
+const sslDisabled = process.env.DATABASE_SSL === 'disable';
 
 const options: Parameters<typeof postgres>[1] = {
   transform: postgres.camel,
-  ssl: isLocal || socketPath ? false : { rejectUnauthorized: false },
+  ssl: sslDisabled || isLocal || socketPath ? false : { rejectUnauthorized: false },
   prepare: false,
   idle_timeout: 20,
   max: 10,


### PR DESCRIPTION
## 概要

`packages/api/src/db/index.ts` の SSL 判定から `DATABASE_SSL === 'disable'` env チェックが消えていた regression を 1 行 (+ 宣言 1 行) で復旧。

Plane Issue: [DLA-13](https://plane.codenica.dev/codenica/projects/d35f178c-4d31-4616-be11-a74c6f1b12db/issues/) (priority=urgent / bug)

## 何が起きていたか

- DLA-11 merge → 自動 deploy で新 image (= `production-5feff29`) が本番 (`duel-log-api`) に上がった直後、 `/api/health` 以外の全 endpoint が DB 接続失敗で ECONNRESET 連発、 ログインも遷移しない状態に
- 緊急で前 image (`production-b8e9365` = `sha256:2315bde7...`) に rollback し復旧済
- 本 PR は再発防止と DLA-11 を再度生かすため

## Root cause

commit `715f2ec1 feat: Supabase→自前認証に移行` で `db/index.ts` を Cloud SQL Auth Proxy (socket 経路) 対応に書き換えた際、 旧コードにあった `process.env.DATABASE_SSL === 'disable'` 判定行が削除された。

codenica-vps 上の本番 / staging container には sops で `DATABASE_SSL=disable` が設定済 (= docker network 内の postgres docker は SSL 非対応で平文接続を期待)。 旧 image はこれを尊重して `ssl: false` で動作していたが、 新 image は env を無視して `ssl: { rejectUnauthorized: false }` で SSL ハンドシェイクを試み、 サーバ側で TCP reset → ECONNRESET。

## 修正内容

```ts
const isLocal = /127\.0\.0\.1|localhost/.test(connectionString);
const sslDisabled = process.env.DATABASE_SSL === 'disable';  // ← 復活

const options: Parameters<typeof postgres>[1] = {
  transform: postgres.camel,
  ssl: sslDisabled || isLocal || socketPath ? false : { rejectUnauthorized: false },
  // ↑ 先頭に sslDisabled を OR
  ...
};
```

SSL 判定の優先順位: `sslDisabled (env)` → `isLocal (127.0.0.1/localhost)` → `socketPath (Cloud SQL)` → デフォルト SSL ON。 旧コード仕様の復元であり新規 logic ではない。

## Test plan

- [ ] CI 通過
- [ ] merge 後の自動 deploy で新 image が立ち上がる
- [ ] codenica-vps で `curl http://127.0.0.1:8011/api/health` が 200 を即返す
- [ ] `duel-log.codenica.dev` のログイン遷移が即時に動く
- [ ] アプリ内フィードバック form (= DLA-11) が Plane Intake に届くこと確認
- [ ] 確認後 `secrets.enc.env.bak.20260517` と `docker-compose.yml.before-rollback` を削除