### PR TITLE
DLA-15 fix: mailer を Brevo HTTP API に切替 (production 起動失敗 fix)

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -17,14 +17,12 @@
     "@hono/zod-openapi": "0.19.10",
     "hono": "^4.12.7",
     "jose": "^6.1.3",
-    "nodemailer": "^7.0.10",
     "postgres": "^3.4.8",
     "zod": "^3.25.76"
   },
   "devDependencies": {
     "@hono/vite-dev-server": "^0.24.1",
     "@types/node": "^25.0.10",
-    "@types/nodemailer": "^7.0.4",
     "dotenv": "^17.2.3",
     "drizzle-kit": "^0.31.8",
     "drizzle-orm": "^0.45.1",

--- a/packages/api/src/lib/mailer.ts
+++ b/packages/api/src/lib/mailer.ts
@@ -1,27 +1,6 @@
-import nodemailer, { type Transporter } from 'nodemailer';
-
-const SMTP_HOST = process.env.SMTP_HOST ?? 'smtp-relay.brevo.com';
-const SMTP_PORT = Number(process.env.SMTP_PORT ?? 587);
-const SMTP_USERNAME = process.env.SMTP_USERNAME;
-const SMTP_PASSWORD = process.env.SMTP_PASSWORD;
-const MAIL_FROM = process.env.MAIL_FROM ?? 'Duel Log <no-reply@duel-log.codenica.dev>';
-
-let transporter: Transporter | null = null;
-
-function getTransporter(): Transporter {
-  if (!transporter) {
-    if (!SMTP_USERNAME || !SMTP_PASSWORD) {
-      throw new Error('SMTP_USERNAME / SMTP_PASSWORD env not configured');
-    }
-    transporter = nodemailer.createTransport({
-      host: SMTP_HOST,
-      port: SMTP_PORT,
-      secure: false,
-      auth: { user: SMTP_USERNAME, pass: SMTP_PASSWORD },
-    });
-  }
-  return transporter;
-}
+const BREVO_API_KEY = process.env.BREVO_API_KEY;
+const MAIL_FROM_NAME = process.env.MAIL_FROM_NAME ?? 'Duel Log';
+const MAIL_FROM_EMAIL = process.env.MAIL_FROM_EMAIL ?? 'no-reply@duel-log.codenica.dev';
 
 export interface SendMailOptions {
   to: string;
@@ -31,10 +10,32 @@ export interface SendMailOptions {
 }
 
 export async function sendMail({ to, subject, text, html }: SendMailOptions): Promise<void> {
-  const tx = getTransporter();
-  await tx.sendMail({ from: MAIL_FROM, to, subject, text, html });
+  if (!BREVO_API_KEY) {
+    throw new Error('BREVO_API_KEY env not configured');
+  }
+
+  const response = await fetch('https://api.brevo.com/v3/smtp/email', {
+    method: 'POST',
+    headers: {
+      'api-key': BREVO_API_KEY,
+      accept: 'application/json',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      sender: { name: MAIL_FROM_NAME, email: MAIL_FROM_EMAIL },
+      to: [{ email: to }],
+      subject,
+      textContent: text,
+      ...(html ? { htmlContent: html } : {}),
+    }),
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text().catch(() => '');
+    throw new Error(`Brevo API error ${response.status}: ${errorBody}`);
+  }
 }
 
 export function isMailerConfigured(): boolean {
-  return Boolean(SMTP_USERNAME && SMTP_PASSWORD);
+  return Boolean(BREVO_API_KEY);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,9 +121,6 @@ importers:
       jose:
         specifier: ^6.1.3
         version: 6.1.3
-      nodemailer:
-        specifier: ^7.0.10
-        version: 7.0.13
       postgres:
         specifier: ^3.4.8
         version: 3.4.8
@@ -137,9 +134,6 @@ importers:
       '@types/node':
         specifier: ^25.0.10
         version: 25.0.10
-      '@types/nodemailer':
-        specifier: ^7.0.4
-        version: 7.0.11
       dotenv:
         specifier: ^17.2.3
         version: 17.2.3
@@ -933,9 +927,6 @@ packages:
   '@types/node@25.0.10':
     resolution: {integrity: sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==}
 
-  '@types/nodemailer@7.0.11':
-    resolution: {integrity: sha512-E+U4RzR2dKrx+u3N4DlsmLaDC6mMZOM/TPROxA0UAPiTgI0y4CEFBmZE+coGWTjakDriRsXG368lNk1u9Q0a2g==}
-
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -1536,10 +1527,6 @@ packages:
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
-
-  nodemailer@7.0.13:
-    resolution: {integrity: sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==}
-    engines: {node: '>=6.0.0'}
 
   openapi3-ts@4.5.0:
     resolution: {integrity: sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==}
@@ -2606,10 +2593,6 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
-  '@types/nodemailer@7.0.11':
-    dependencies:
-      '@types/node': 25.0.10
-
   '@types/react-dom@19.2.3(@types/react@19.2.9)':
     dependencies:
       '@types/react': 19.2.9
@@ -3083,8 +3066,6 @@ snapshots:
       whatwg-url: 5.0.0
 
   node-releases@2.0.27: {}
-
-  nodemailer@7.0.13: {}
 
   openapi3-ts@4.5.0:
     dependencies:


### PR DESCRIPTION
## Summary
PR #419 の DLA-15 が production deploy で起動失敗したため緊急 fix。

### 障害
production container が起動直後 crash (= `Error: Dynamic require of "events" is not supported`)。 root cause は nodemailer 内部の CommonJS require が esbuild ESM bundle 経路で動的 require shim に変換されてしまい、 runtime で実行不能になっていたこと。

### 対応
- production を 1 つ前の image (`sha256:d4877aebe956...`) に **rollback 済** (`/api/health` 200 復旧確認、 2026-05-19 14:20 JST)
- 本 PR で mailer を **nodemailer から Brevo HTTP API (= POST /v3/smtp/email)** に切替。 外部依存を native fetch のみにすることで esbuild bundle 問題を解消
- env 変更:
  - 旧: `SMTP_HOST` / `SMTP_PORT` / `SMTP_USERNAME` / `SMTP_PASSWORD` / `MAIL_FROM` (= 未使用化、 後 Issue で cleanup)
  - 新: `BREVO_API_KEY` + `MAIL_FROM_NAME` + `MAIL_FROM_EMAIL`
- codenica-vps の sops (`/opt/duel-log-api{,-staging}/secrets.enc.env`) に新 env 投入済

## Test plan
- [x] ローカル typecheck / lint pass
- [ ] CI 通過 (= typecheck / lint / test)
- [ ] main merge 後の自動 deploy で health check 通過
- [ ] `/forgot-password` から reset 試行 → mail 受信 → `/reset-password` で更新 → 新 password でログイン

## Plane
DLA-15 (urgent): https://plane.codenica.dev/codenica/projects/d35f178c-4d31-4616-be11-a74c6f1b12db/issues/