### PR TITLE
DLA-9 fix: iOS Safari で編集ダイアログがタップで閉じる問題を再修正

### DIFF
--- a/apps/web/src/components/dashboard/DuelFormDialog.tsx
+++ b/apps/web/src/components/dashboard/DuelFormDialog.tsx
@@ -855,8 +855,11 @@ export function DuelFormDialog({
     <div
       className="dialog-overlay"
       onClick={(e) => {
-        // iOS Safari fires click events that can bypass stopPropagation on child elements.
-        // Guard: only close when the overlay itself (not any child) was the tap target.
+        // iOS Safari は input/select/button などをタップした際、 子で stopPropagation していても
+        // overlay 自身を target とする synthetic click を別途発火することがある。
+        // e.target === e.currentTarget ガードでも誤閉じが残るため、 タッチ環境では外側タップで
+        // 閉じない (= 編集中の入力ロストを防ぐ)。 close は X / Cancel / Escape のみ。
+        if (typeof window !== 'undefined' && window.matchMedia('(pointer: coarse)').matches) return;
         if (e.target === e.currentTarget) onClose();
       }}
       onKeyDown={(e) => e.key === 'Escape' && onClose()}


### PR DESCRIPTION
## Summary
- iOS Safari 26.4 でも残っていた「対戦履歴の編集ダイアログが画面内タップで閉じる」 を再修正
- タッチ環境 (`pointer: coarse`) では外側タップ close を完全無効化、 close は X / Cancel / Escape のみに限定 (= 編集中入力ロスト防止)
- デスクトップは従来通り外側 click で close 可能

## 影響範囲
- `apps/web/src/components/dashboard/DuelFormDialog.tsx` のみ
- 同種パターンを持つ他 Dialog (UserDetailDialog / DeckFormDialog / CsvImportDialog / StatsImageDialog / ShareStatsDialog / FeedbackView / ProfileView) は Issue scope 外で touch せず

## Test plan
- [x] pnpm typecheck pass
- [x] pnpm lint pass (118 files clean)
- [x] pnpm test pass (24 tests)
- [ ] main merge 後 production deploy で実機 (iPhone 17 / iOS 26.4 / Safari) 動作確認

## 関連
Plane: DLA-9