### PR TITLE
infra: staging CI に VPS API 自動デプロイを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,43 @@ jobs:
           GOOGLE_CLOUD_REGION: ${{ env.GOOGLE_CLOUD_REGION }}
           FIREBASE_HOSTING_SITE: ${{ env.FIREBASE_HOSTING_SITE }}
 
+      - name: Build & push API image to Artifact Registry
+        id: build_api
+        run: |
+          set -euo pipefail
+          SHORT_SHA="${GITHUB_SHA:0:7}"
+          IMAGE_TAG="${GOOGLE_CLOUD_REGION}-docker.pkg.dev/${GOOGLE_CLOUD_PROJECT}/${ARTIFACT_REGISTRY_REPO}/api:staging-${SHORT_SHA}"
+          gcloud builds submit --project "$GOOGLE_CLOUD_PROJECT" --config deploy/google/cloudbuild.api.yaml --substitutions=_IMAGE="$IMAGE_TAG"
+          DIGEST=$(gcloud artifacts docker images describe "$IMAGE_TAG" --format='value(image_summary.digest)')
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: Mint Artifact Registry access token
+        id: gcloud_token
+        run: echo "token=$(gcloud auth print-access-token)" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy API container to codenica-vps (staging)
+        uses: appleboy/ssh-action@v1.2.0
+        env:
+          GCLOUD_TOKEN: ${{ steps.gcloud_token.outputs.token }}
+          IMAGE_DIGEST: ${{ steps.build_api.outputs.digest }}
+        with:
+          host: ${{ vars.VPS_HOST }}
+          username: ${{ vars.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          envs: GCLOUD_TOKEN,IMAGE_DIGEST
+          script: |
+            set -euo pipefail
+            cd /opt/duel-log-api-staging
+            echo "$GCLOUD_TOKEN" | docker login -u oauth2accesstoken --password-stdin https://asia-northeast1-docker.pkg.dev
+            sed -i.bak -E "s|apps/api@sha256:[a-f0-9]+|apps/api@${IMAGE_DIGEST}|" docker-compose.yml
+            docker compose pull
+            ./up.sh
+            for i in 1 2 3 4 5 6 7 8 9 10; do
+              if curl -fsS http://127.0.0.1:8001/api/health >/dev/null 2>&1; then echo "staging deploy OK (attempt $i)"; exit 0; fi
+              sleep 3
+            done
+            echo "health check failed after 30s"; docker logs duel-log-api-staging --tail 50; exit 1
+
       - name: Write summary
         run: |
           {


### PR DESCRIPTION
## 概要

`ci.yml` の `deploy-staging` ジョブ（staging ブランチ push 時）に、本番(`deploy.yml`)同様の **codenica-vps への API コンテナ自動デプロイ**を追加。従来 `deploy-staging` は Firebase Hosting（フロント）のみで、staging API コンテナ(`/opt/duel-log-api-staging`)は手動更新が必要だった。

## 追加 step

- **Build & push API image**: `deploy/google/cloudbuild.api.yaml` で `api:staging-<sha>` をビルドし digest 取得
- **Mint access token**: `gcloud auth print-access-token` で Artifact Registry pull 用トークン取得
- **Deploy API container (staging)**: VPS に SSH → `docker-compose.yml` の digest 差替 → `docker compose pull` → `up.sh` → `127.0.0.1:8001/api/health` をリトライ確認

`vars.VPS_HOST`/`vars.VPS_USER`/`secrets.VPS_SSH_KEY` は `deploy.yml` と共用。

## 検証

staging ブランチで実行済み（本 PR と同一コミット）。`deploy-staging` の3 step が全て成功し、staging コンテナが CI ビルドの新イメージで再作成・health ok を確認済み。

## 補足

main の `deploy-staging` は `if: github.ref == 'refs/heads/staging'` のため main では発火しない。本 PR は source of truth 統一が目的。staging ブランチと main は別途乖離あり（dev用DBツーリング等）だが本変更とは独立。