### PR TITLE
fix: 管理者統計の総デッキ数・アクティブ人数を追加しパス不一致を修正

### DIFF
--- a/apps/web/src/components/admin/AdminView.tsx
+++ b/apps/web/src/components/admin/AdminView.tsx
@@ -32,7 +32,7 @@ export function AdminView() {
 
   const { data: stats, isLoading: statsLoading } = useQuery({
     queryKey: ['admin', 'stats'],
-    queryFn: () => api<{ data: AdminStats }>('/admin/stats'),
+    queryFn: () => api<{ data: AdminStats }>('/admin/statistics'),
   });
 
   const { data: users, isLoading: usersLoading } = useQuery({
@@ -81,7 +81,7 @@ export function AdminView() {
       color: 'var(--color-secondary)',
     },
     {
-      label: t('admin.activeToday'),
+      label: t('admin.active30d'),
       value: stats?.data.activeUsers30d ?? 0,
       color: 'var(--color-warning)',
     },

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -312,7 +312,7 @@
     "totalUsers": "Total Users",
     "totalDuels": "Total Duels",
     "totalDecks": "Total Decks",
-    "activeToday": "Active Today",
+    "active30d": "Active (30d)",
     "userList": "User List",
     "maintenance": "Maintenance",
     "deleteExpiredLinks": "Delete expired share links",

--- a/apps/web/src/locales/ja.json
+++ b/apps/web/src/locales/ja.json
@@ -312,7 +312,7 @@
     "totalUsers": "総ユーザー数",
     "totalDuels": "総対戦数",
     "totalDecks": "総デッキ数",
-    "activeToday": "本日アクティブ",
+    "active30d": "アクティブ (30日)",
     "userList": "ユーザー一覧",
     "maintenance": "メンテナンス",
     "deleteExpiredLinks": "期限切れ共有リンクを削除",

--- a/apps/web/src/locales/ko.json
+++ b/apps/web/src/locales/ko.json
@@ -312,7 +312,7 @@
     "totalUsers": "총 사용자 수",
     "totalDuels": "총 듀얼 수",
     "totalDecks": "총 덱 수",
-    "activeToday": "오늘 활성",
+    "active30d": "활성 (30일)",
     "userList": "사용자 목록",
     "maintenance": "유지보수",
     "deleteExpiredLinks": "만료된 공유 링크 삭제",

--- a/packages/api/src/services/__tests__/admin.test.ts
+++ b/packages/api/src/services/__tests__/admin.test.ts
@@ -87,6 +87,8 @@ describe('admin service', () => {
       expect(result).toHaveProperty('totalUsers');
       expect(result).toHaveProperty('totalDuels');
       expect(result).toHaveProperty('todayDuels');
+      expect(result).toHaveProperty('totalDecks');
+      expect(result).toHaveProperty('activeUsers30d');
     });
 
     it('returns zero counts when no data', async () => {
@@ -98,6 +100,8 @@ describe('admin service', () => {
       expect(result.totalUsers).toBe(0);
       expect(result.totalDuels).toBe(0);
       expect(result.todayDuels).toBe(0);
+      expect(result.totalDecks).toBe(0);
+      expect(result.activeUsers30d).toBe(0);
     });
   });
 });

--- a/packages/api/src/services/admin.ts
+++ b/packages/api/src/services/admin.ts
@@ -24,10 +24,18 @@ export async function getAdminStatistics() {
   const [todayDuels] = await sql<{ count: number }[]>`
     SELECT count(*)::int AS count FROM duels WHERE created_at >= current_date
   `;
+  const [deckCount] = await sql<{ count: number }[]>`
+    SELECT count(*)::int AS count FROM decks WHERE is_opponent_deck = false
+  `;
+  const [activeUsers] = await sql<{ count: number }[]>`
+    SELECT count(*)::int AS count FROM users WHERE last_login_at >= now() - interval '30 days'
+  `;
 
   return {
     totalUsers: userCount?.count ?? 0,
     totalDuels: duelCount?.count ?? 0,
     todayDuels: todayDuels?.count ?? 0,
+    totalDecks: deckCount?.count ?? 0,
+    activeUsers30d: activeUsers?.count ?? 0,
   };
 }


### PR DESCRIPTION
## 概要
管理者ツールの統計値 4 種 (総人数・総対戦数・総デッキ数・アクティブ人数) を正しく表示するよう修正。

## 変更
- パス不一致 (`/admin/stats` → `/admin/statistics`) を解消し、統計取得の 404 を修正
- バックエンドに `totalDecks` (自分デッキのみ = `is_opponent_deck=false`) / `activeUsers30d` (過去30日ログイン = `last_login_at >= now() - 30 days`) の集計を追加
- 表示ラベル i18n キーを `activeToday` → `active30d` にリネーム (ja/en/ko、定義と整合)

## 検証
- admin テスト 7 passed / typecheck 全プロジェクト通過 / biome lint clean