### PR TITLE
fix: ログインのメール検索を大文字小文字無視にして大文字メールユーザーが弾かれる不具合を修正

### DIFF
--- a/db/migrations/20260525000000_email_case_insensitive_index.sql
+++ b/db/migrations/20260525000000_email_case_insensitive_index.sql
@@ -1,0 +1,9 @@
+-- email 検索を大文字小文字無視にするための関数インデックス。
+-- login / register / forgot / oauth の検索が `WHERE lower(email) = $1` を使うため、
+-- 既存の UNIQUE(email) インデックスは効かず seq scan になる。それを避ける。
+--
+-- NOTE: 本来は UNIQUE にして大文字違いの重複登録を DB レベルで防ぎたいが、
+-- 既存データに lower(email) 重複が 1 組残っている
+-- (Supabase 時代の大文字 password 版 + 後から作られた小文字 Google OAuth 版)。
+-- その組を統合してから別マイグレーションで UNIQUE 化する。
+CREATE INDEX IF NOT EXISTS users_email_lower_idx ON users (lower(email));

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -142,7 +142,7 @@ async function findOrCreateOAuthUser(
 
   [user] = await sql<UserRow[]>`
     SELECT * FROM users
-    WHERE email = ${email}
+    WHERE lower(email) = ${email}
   `;
   if (user) {
     const [updated] = await sql<UserRow[]>`
@@ -173,7 +173,7 @@ export const authRoutes = new Hono()
     const { email, password } = loginSchema.parse(await c.req.json());
 
     const [user] = await sql<UserRow[]>`
-      SELECT * FROM users WHERE email = ${email}
+      SELECT * FROM users WHERE lower(email) = ${email}
     `;
 
     if (!user?.passwordHash || !(await passwordMatches(password, user.passwordHash))) {
@@ -196,7 +196,7 @@ export const authRoutes = new Hono()
     const { email, password, displayName } = registerSchema.parse(await c.req.json());
 
     const [existing] = await sql<Pick<UserRow, 'id'>[]>`
-      SELECT id FROM users WHERE email = ${email}
+      SELECT id FROM users WHERE lower(email) = ${email}
     `;
     if (existing) {
       return c.json(
@@ -272,7 +272,7 @@ export const authRoutes = new Hono()
     const { email } = forgotPasswordSchema.parse(await c.req.json());
 
     const [user] = await sql<UserRow[]>`
-      SELECT * FROM users WHERE email = ${email}
+      SELECT * FROM users WHERE lower(email) = ${email}
     `;
 
     if (user?.passwordHash && user.status === 'active') {


### PR DESCRIPTION
## 概要
本番で「一部ユーザーがログインできない」不具合の恒久対策。

## 原因
DB の `email` は case-sensitive な `TEXT UNIQUE`。Supabase→自前認証移行時に大文字混じりで保存された 16 ユーザーが、小文字化したログイン入力 (`WHERE email = $lower`) と一致せず `401 INVALID_CREDENTIALS` で弾かれていた。小文字メールのユーザーは影響を受けないため「一部だけ」入れない症状になっていた。

## 修正
- login / register / forgot / oauth の email 検索を `WHERE lower(email) = $1` に変更 (入力は emailSchema で小文字化済み)
- 性能用の関数インデックス `users_email_lower_idx` を追加

## 検証
- `typecheck` / 既存 79 テスト緑
- staging 実地検証: 大文字メール `CaseVerify.Test@Example.com` のユーザーで login が `200` + `Set-Cookie` を返すことを確認 (修正前は `401`)

## 補足 (この PR の範囲外)
- 本番 DB の大文字メール **15 件は小文字化済み** (被害者は救済済み)
- 関数インデックスの本番適用は手動 (CI に migrate job なし)。702 行規模で性能影響は軽微
- `lower(email)` 重複 1 組 (大文字 password 版 + 小文字 Google 版、同一人物) は UNIQUE 化前に統合が必要なため保留