### PR TITLE
enhance: email の lower(email) インデックスを UNIQUE 化して重複登録を防止

### DIFF
--- a/db/migrations/20260525000000_email_case_insensitive_index.sql
+++ b/db/migrations/20260525000000_email_case_insensitive_index.sql
@@ -1,9 +1,8 @@
--- email 検索を大文字小文字無視にするための関数インデックス。
--- login / register / forgot / oauth の検索が `WHERE lower(email) = $1` を使うため、
--- 既存の UNIQUE(email) インデックスは効かず seq scan になる。それを避ける。
+-- email を大文字小文字無視で扱うための UNIQUE 関数インデックス。
+-- login / register / forgot / oauth は入力を小文字化して `WHERE lower(email) = $1`
+-- で検索する。UNIQUE 化により大文字違いの重複登録を DB レベルで防ぐ。
 --
--- NOTE: 本来は UNIQUE にして大文字違いの重複登録を DB レベルで防ぎたいが、
--- 既存データに lower(email) 重複が 1 組残っている
--- (Supabase 時代の大文字 password 版 + 後から作られた小文字 Google OAuth 版)。
--- その組を統合してから別マイグレーションで UNIQUE 化する。
-CREATE INDEX IF NOT EXISTS users_email_lower_idx ON users (lower(email));
+-- 2026-05-25: 既存データの大文字混じり email 15 件は小文字化済み。残る lower(email)
+-- 重複 1 組 (大文字 password 版 + 小文字 Google 版、同一 Gmail) はデッキを現用アカウント
+-- に移して統合済み。本番 duellog / staging duellog_staging には手動適用済み。
+CREATE UNIQUE INDEX IF NOT EXISTS users_email_lower_idx ON users (lower(email));


### PR DESCRIPTION
## 概要
`lower(email)` 関数インデックスを UNIQUE 化し、大文字違いの重複登録を DB レベルで防止。PR #429 (lower(email) 検索化) の再発防止を完成させる。

## 補足
- 本番 `duellog` / staging `duellog_staging` には**既に手動適用済み** (UNIQUE インデックス作成 + 衝突組統合)。本 PR はコードベースの記録を実体に揃えるもので、本番 API の挙動は変わらない (マージ時の再デプロイは瞬断のみ)。
- 衝突組 (大文字 password 版 + 小文字 Google 版・同一 Gmail) は、旧アカウントのデッキ 2 件を現用 Google アカウントに移してから統合済み。