### PR TITLE
fix: CSRF cookie path 不具合で本番の mutation 系が全て 403 になる障害を修正

### DIFF
--- a/packages/api/src/lib/__tests__/cookies.test.ts
+++ b/packages/api/src/lib/__tests__/cookies.test.ts
@@ -50,7 +50,7 @@ describe('setAuthCookies', () => {
     expect(refreshCookie).toMatch(/Path=\/api\/auth(;|$| )/);
   });
 
-  it('dlog_csrf は HttpOnly を含まない / Path=/api で値が CT', async () => {
+  it('dlog_csrf は HttpOnly を含まない / Path=/ で値が CT', async () => {
     const app = buildApp();
     const res = await app.request('/set', { method: 'POST' });
     const cookies = res.headers.getSetCookie();
@@ -59,7 +59,8 @@ describe('setAuthCookies', () => {
     expect(csrfCookie).toContain(`${COOKIE_NAMES.csrf}=CT`);
     // HttpOnly が付いていないことを確認（フロントが読む必要があるため）
     expect(csrfCookie).not.toMatch(/HttpOnly/i);
-    expect(csrfCookie).toMatch(/Path=\/api(;|$| )/);
+    // SPA (path=/ 配下) から document.cookie で読めるよう Path=/ であること
+    expect(csrfCookie).toMatch(/Path=\/(;|$| )/);
   });
 });
 

--- a/packages/api/src/lib/__tests__/cookies.test.ts
+++ b/packages/api/src/lib/__tests__/cookies.test.ts
@@ -16,7 +16,7 @@ function buildApp() {
 }
 
 describe('setAuthCookies', () => {
-  it('3 本の Set-Cookie を返す（dlog_access, dlog_refresh, dlog_csrf）', async () => {
+  it('access / refresh / csrf(path=/) + 旧 csrf(path=/api) 無効化の 4 本を返す', async () => {
     const app = buildApp();
     const res = await app.request('/set', { method: 'POST' });
     const cookies = res.headers.getSetCookie();
@@ -24,7 +24,9 @@ describe('setAuthCookies', () => {
     expect(names).toContain(COOKIE_NAMES.access);
     expect(names).toContain(COOKIE_NAMES.refresh);
     expect(names).toContain(COOKIE_NAMES.csrf);
-    expect(cookies).toHaveLength(3);
+    // csrf は新 path=/ の set と 旧 path=/api の無効化で 2 本出る
+    expect(cookies.filter((c) => c.startsWith(`${COOKIE_NAMES.csrf}=`))).toHaveLength(2);
+    expect(cookies).toHaveLength(4);
   });
 
   it('dlog_access は HttpOnly / Path=/api / SameSite=Lax で値が AT', async () => {

--- a/packages/api/src/lib/cookies.ts
+++ b/packages/api/src/lib/cookies.ts
@@ -16,9 +16,12 @@ export const CSRF_HEADER = 'X-CSRF-Token';
 const ACCESS_MAX_AGE = 60 * 60; // 1h
 const REFRESH_MAX_AGE = 60 * 60 * 24 * 30; // 30d
 
-// access / csrf は全 API に送る。refresh は auth 系にだけ送る（最小権限）
+// access は全 API に送る。refresh は auth 系にだけ送る（最小権限）
 const BASE_PATH = '/api';
 const REFRESH_PATH = '/api/auth';
+// csrf はフロント (SPA, path=/ 配下) が document.cookie で読む必要があるため path=/。
+// path=/api だと SPA のページから読めず X-CSRF-Token を付けられない（= 全 mutation が 403）。
+const CSRF_PATH = '/';
 
 // 本番のみ Secure（dev は http localhost なので付けない）。
 // Domain 未指定なら発行ホスト限定（dev で素直に動く）。本番は `.codenica.dev` を渡して same-site 共有。
@@ -49,11 +52,12 @@ export function setAuthCookies(
     path: REFRESH_PATH,
     maxAge: REFRESH_MAX_AGE,
   });
-  // CSRF token はフロントが読んで X-CSRF-Token ヘッダに載せるため httpOnly にしない
+  // CSRF token はフロントが読んで X-CSRF-Token ヘッダに載せるため httpOnly にしない。
+  // path=/ にして SPA のどのページからも document.cookie で読めるようにする。
   setCookie(c, COOKIE_NAMES.csrf, tokens.csrfToken, {
     ...baseOptions(),
     httpOnly: false,
-    path: BASE_PATH,
+    path: CSRF_PATH,
     maxAge: REFRESH_MAX_AGE,
   });
 }
@@ -61,5 +65,5 @@ export function setAuthCookies(
 export function clearAuthCookies(c: Context): void {
   deleteCookie(c, COOKIE_NAMES.access, { ...baseOptions(), path: BASE_PATH });
   deleteCookie(c, COOKIE_NAMES.refresh, { ...baseOptions(), path: REFRESH_PATH });
-  deleteCookie(c, COOKIE_NAMES.csrf, { ...baseOptions(), path: BASE_PATH });
+  deleteCookie(c, COOKIE_NAMES.csrf, { ...baseOptions(), path: CSRF_PATH });
 }

--- a/packages/api/src/lib/cookies.ts
+++ b/packages/api/src/lib/cookies.ts
@@ -60,10 +60,15 @@ export function setAuthCookies(
     path: CSRF_PATH,
     maxAge: REFRESH_MAX_AGE,
   });
+  // 旧実装で path=/api 発行された csrf cookie が残っていると、新しい path=/ cookie と
+  // 二重に送られサーバーが旧値を拾って不一致 403 になりうる。旧 path のものを無効化する。
+  deleteCookie(c, COOKIE_NAMES.csrf, { ...baseOptions(), path: BASE_PATH });
 }
 
 export function clearAuthCookies(c: Context): void {
   deleteCookie(c, COOKIE_NAMES.access, { ...baseOptions(), path: BASE_PATH });
   deleteCookie(c, COOKIE_NAMES.refresh, { ...baseOptions(), path: REFRESH_PATH });
   deleteCookie(c, COOKIE_NAMES.csrf, { ...baseOptions(), path: CSRF_PATH });
+  // 旧 path=/api で残っている csrf cookie も無効化（移行期の取りこぼし防止）
+  deleteCookie(c, COOKIE_NAMES.csrf, { ...baseOptions(), path: BASE_PATH });
 }


### PR DESCRIPTION
## 概要

本番 (duel-log.codenica.dev) で全ユーザーのログアウト・データ登録など mutation 系が `403 CSRF_FAILED` で全滅していた障害の緊急 hotfix。

## 原因

httpOnly cookie 化 (#73094d82) 時、`dlog_csrf` を `path=/api` で発行していた。SPA は `/`, `/decks` などルート配下のページで動くため、`document.cookie` から `path=/api` の cookie を読めず、`X-CSRF-Token` ヘッダを付けられないまま全 POST/PUT/DELETE が CSRF 検証で 403 になっていた (GET=閲覧と CSRF 免除のログインは通る)。

ブラウザコンソールで確認:
```
POST /api/auth/signout 403 (Forbidden)
POST /api/decks 403 (Forbidden)  ApiError: CSRF token mismatch
```

## 修正

- `dlog_csrf` の path を `/api` → `/` に変更。SPA から読めるようになり、`/api/*` へも送られ続けるためサーバー側 double-submit 検証は維持。
- 移行期に旧 `path=/api` の csrf cookie がブラウザに残ると二重送信で不一致 403 が継続しうるため、ログイン/リフレッシュ/ログアウト時に旧 path のものを無効化。再ログインだけで自動回復する (cookie 手動削除不要)。
- access/refresh は httpOnly でクライアント非読取なので `path=/api` のまま据え置き。

## 検証

- API テスト 79 件 pass / typecheck pass
- staging は main のちょうど 2 コミット先 (本修正のみ)、余計な変更は混ざらない

緊急 hotfix のため staging API での動作確認フェーズは飛ばす判断。